### PR TITLE
Rolling deployments

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -27,10 +27,6 @@ To use the following scripts, first run `npm install`
 
   Script to initialise/update Kubernetes deployments for a platform environment
 
-- `scripts/restart_platform_pods.sh`
-
-  Script to explicitly restart pods in a platform environment
-
 All these scripts print out their usage instructions by being run with the `-h` flag
 
 ## Configuration files
@@ -97,7 +93,7 @@ See the `Makefile` for more info.
 
     Rails secret
 
-- Run the `scripts/deploy_platform.sh` script which 
+- Run the `scripts/deploy_platform.sh` script which
 
   - generates the necessary kubernetees configuration to deploy the application
   - applies the configuration
@@ -105,37 +101,3 @@ See the `Makefile` for more info.
     NB. as the network policies define cross-namespace access, you MUST NOT supply a namespace parameter for the service token cache app - each item defines its own namespace metadata
 
 The generated config for each platform/deployment environment combination is written to `/tmp/fb-submitter-$PLATFORM_ENV-$DEPLOYMENT_ENV.yaml`
-
-### 4. Deploying an updated docker image to existing infrastructure
-
-Deleting the currently running pods will trigger the kubernetes Deployment to recreate pods until it has its specified minimum number running - as the Deployment has `imagePullPolicy: Always`, it will pull the latest docker image from Cloud Platform's ECR.
-
-`scripts/restart_platform_pods.sh` is a convenience script that deletes all pods in all deployment environments accross a platform environment.
-
-Running
-
-```bash
-scripts/restart_platform_pods.sh -p $PLATFORM_ENV
-```
-
-is equivalent to
-
-```bash
-kubectl delete pods -l appGroup=fb-submitter --namespace=formbuilder-platform-$PLATFORM_ENV-dev &\
-kubectl delete pods -l appGroup=fb-submitter --namespace=formbuilder-platform-$PLATFORM_ENV-staging &\
-kubectl delete pods -l appGroup=fb-submitter --namespace=formbuilder-platform-$PLATFORM_ENV-production &
-```
-
-To restart just the `api` pods in a specific deployment environment
-
-```bash
-kubectl delete pods -l app=fb-submitter-api-$PLATFORM_ENV-$DEPLOYMENT_ENV  --namespace=formbuilder-platform-$PLATFORM_ENV-$DEPLOYMENT_ENV &
-```
-
-To restart just the `worker` pods in a specific deployment environment
-
-```bash
-kubectl delete pods -l app=fb-submitter-workers-$PLATFORM_ENV-$DEPLOYMENT_ENV --namespace=formbuilder-platform-$PLATFORM_ENV-$DEPLOYMENT_ENV
-```
-
-

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ target:
 ifeq ($(TARGETDEFINED), "true")
 	$(eval export env_stub=${TARGET})
 	@true
-else 
+else
 	$(info Must set TARGET)
 	@false
 endif
@@ -42,12 +42,12 @@ install_build_dependencies: init
 
 # Needs ECR_REPO_NAME & ECR_REPO_URL env vars
 build: install_build_dependencies
-	TAG="latest-${env_stub}" REPO_SCOPE=${ECR_REPO_URL_ROOT} ./scripts/build_all.sh
+	TAG="latest-${env_stub}" REPO_SCOPE=${ECR_REPO_URL_ROOT} CIRCLE_SHA1=${CIRCLE_SHA1} ./scripts/build_all.sh
 
 push: init
-	TAG="latest-${env_stub}" REPO_SCOPE=${ECR_REPO_URL_ROOT} ./scripts/push_all.sh
+	TAG="latest-${env_stub}" REPO_SCOPE=${ECR_REPO_URL_ROOT} CIRCLE_SHA1=${CIRCLE_SHA1} ./scripts/push_all.sh
 
 build_and_push: install_build_dependencies
-	TAG="latest-${env_stub}" REPO_SCOPE=${ECR_REPO_URL_ROOT} ./scripts/build_and_push_all.sh
+	TAG="latest-${env_stub}" REPO_SCOPE=${ECR_REPO_URL_ROOT} CIRCLE_SHA1=${CIRCLE_SHA1} ./scripts/build_and_push_all.sh
 
 .PHONY := init push build login

--- a/deploy/fb-submitter-chart/templates/deployment.yaml
+++ b/deploy/fb-submitter-chart/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: "fb-submitter-api-{{ .Values.environmentName }}"
-        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-submitter-api:latest-{{ .Values.platformEnv }}"
+        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-submitter-api:{{ .Values.circleSha1 }}"
         securityContext:
           runAsUser: 1001
         imagePullPolicy: Always
@@ -80,7 +80,7 @@ spec:
       serviceAccountName: "formbuilder-submitter-workers-{{ .Values.environmentName }}"
       containers:
       - name: "fb-submitter-worker"
-        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-submitter-worker:latest-{{ .Values.platformEnv }}"
+        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-submitter-worker:{{ .Values.circleSha1 }}"
         imagePullPolicy: Always
         # command:
         #   - "cd /var/www/fb-submitter && bundle exec rake resque:work"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/ministryofjustice/fb-submitter#readme",
   "dependencies": {},
   "devDependencies": {
-    "@ministryofjustice/fb-deploy-utils": "^1.0.6"
+    "@ministryofjustice/fb-deploy-utils": "^1.0.10"
   }
 }

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -9,5 +9,5 @@ for TYPE in base api worker
 do
   REPO_NAME=${REPO_SCOPE}/fb-submitter-${TYPE}
   echo "Building ${REPO_NAME}"
-  docker build -f docker/${TYPE}/Dockerfile -t ${REPO_NAME}:${TAG} --build-arg BASE_IMAGE=${REPO_SCOPE}/fb-submitter-base .
+  docker build -f docker/${TYPE}/Dockerfile -t ${REPO_NAME}:${TAG} -t ${REPO_NAME}:${CIRCLE_SHA1} --build-arg BASE_IMAGE=${REPO_SCOPE}/fb-submitter-base .
 done

--- a/scripts/build_and_push_all.sh
+++ b/scripts/build_and_push_all.sh
@@ -25,9 +25,10 @@ for TYPE in base api worker
 do
   REPO_NAME=${REPO_SCOPE}/fb-submitter-${TYPE}
   echo "Building ${REPO_NAME}"
-  docker build -f docker/${TYPE}/Dockerfile -t ${REPO_NAME}:${TAG} --build-arg BASE_IMAGE=${REPO_SCOPE}/fb-submitter-base:${TAG} .
+  docker build -f docker/${TYPE}/Dockerfile -t ${REPO_NAME}:${TAG} -t ${REPO_NAME}:${CIRCLE_SHA1} --build-arg BASE_IMAGE=${REPO_SCOPE}/fb-submitter-base:${TAG} .
 
   login_to_ecr_with_creds_for ${TYPE}
   echo "Pushing ${REPO_NAME}"
   docker push ${REPO_NAME}:${TAG}
+  docker push ${REPO_NAME}:${CIRCLE_SHA1}
 done

--- a/scripts/circleci_deploy.sh
+++ b/scripts/circleci_deploy.sh
@@ -20,7 +20,4 @@ echo "kubectl use circleci context"
 kubectl config use-context "circleci_${environment_name}_${deployment_name}"
 
 echo "apply kubernetes changes to ${environment_name} ${deployment_name}"
-./scripts/deploy_platform.sh -p $environment_name -d $deployment_name
-
-echo "delete pods in ${environment_name} ${deployment_name}"
-./scripts/restart_platform_pods.sh -p $environment_name -d $deployment_name -c "circleci_${environment_name}_${deployment_name}"
+./scripts/deploy_platform.sh -p $environment_name -d $deployment_name -s $CIRCLE_SHA1

--- a/scripts/push_all.sh
+++ b/scripts/push_all.sh
@@ -27,4 +27,5 @@ do
   eval $(aws ecr get-login --no-include-email --region eu-west-2)
   echo "Pushing ${REPO_NAME}"
   docker push ${REPO_NAME}:${TAG}
+  docker push ${REPO_NAME}:${CIRCLE_SHA1}
 done

--- a/scripts/restart_platform_pods.sh
+++ b/scripts/restart_platform_pods.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-FB_APPLICATION='fb-submitter' node_modules/\@ministryofjustice/fb-deploy-utils/bin/restart_platform_pods.sh $@


### PR DESCRIPTION
Instead of manually deleting pods (resulting in downtime), use kubernetes
built-in rolling deployments.  This requires a dynamic tag on the container
image that can be referred to by the Helm deployment.yaml file.

By simply using a tag like latest, that never changes, kubernetes won't pick up
that anything has changed and not deploy.