### PR TITLE
Add minimum coverage and format output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'simplecov'
+  gem 'simplecov-console', require: false
   gem 'webmock'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    ansi (1.5.0)
     arel (9.0.0)
     aws-eventstream (1.0.2)
     aws-partitions (1.144.0)
@@ -253,6 +254,10 @@ GEM
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
+    simplecov-console (0.5.0)
+      ansi
+      simplecov
+      terminal-table
     simplecov-html (0.10.2)
     sinatra (2.0.4)
       mustermann (~> 1.0)
@@ -266,6 +271,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -274,6 +281,7 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.6.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
     webmock (3.4.2)
@@ -317,6 +325,7 @@ DEPENDENCIES
   sentry-raven
   shoulda-matchers (~> 3.1)
   simplecov
+  simplecov-console
   timecop
   typhoeus
   tzinfo-data

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,7 +100,14 @@ RSpec.configure do |config|
 end
 
 require 'simplecov'
+require 'simplecov-console'
+
 SimpleCov.start do
   add_filter '/config/'
   add_filter '/spec/'
 end
+SimpleCov.minimum_coverage 90
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::Console
+])


### PR DESCRIPTION
I've added a minimum code coverage at the current coverage level to ensure code coverage does not decrease. We can work towards 100% coverage in subsequent PRs.

Also added a nice formatter to clearly display coverage results:
<img width="869" alt="Screenshot 2019-06-25 at 16 46 10" src="https://user-images.githubusercontent.com/2160769/60113053-e3750200-9768-11e9-9cde-bfc7fa699a68.png">
