### PR TITLE
adding sentry ENV param to api front-end

### DIFF
--- a/deploy/fb-submitter-chart/templates/deployment.yaml
+++ b/deploy/fb-submitter-chart/templates/deployment.yaml
@@ -56,6 +56,11 @@ spec:
               secretKeyRef:
                 name: elasticache-formbuilder-submitter-{{ .Values.environmentName }}
                 key: primary_endpoint_address
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: fb-submitter-app-secrets-{{ .Values.environmentName }}
+                key: sentry_dsn
 ---
 # workers
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
Previously missed this and the param was only set for the workers 