### PR TITLE
handle html and text for metrics

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -23,6 +23,7 @@ class MetricsController < ActionController::Base
   def show
     respond_to do |f|
       f.text
+      f.html { render template: 'metrics/show.text' }
     end
   end
 

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe MetricsController do
         queues: 3,
         workers: 4,
         working: 5,
-        working: 6,
-        failed: 7
+        failed: 6
       }
     end
 

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe MetricsController do
       expect(response).to be_successful
     end
 
+    it 'works' do
+      get :show, format: 'html'
+      expect(response).to be_successful
+    end
+
     it 'returns prometheus metrics' do
       get :show, format: 'text'
       body = response.body


### PR DESCRIPTION
service monitor does not seem to accept text/plain so fails
adding html compatability