### PR TITLE
Add Kubernetes readiness probe

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,5 @@
+class HealthController < ActionController::API
+  def show
+    render plain: 'healthy'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     mount Rswag::Api::Engine => '/api-docs'
   end
 
+  get '/health', to: 'health#show'
   get '/submission/:id', to: 'submission#show'
   post '/submission', to: 'submission#create'
 

--- a/deploy/fb-submitter-chart/templates/deployment.yaml
+++ b/deploy/fb-submitter-chart/templates/deployment.yaml
@@ -22,6 +22,13 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
         # non-secret env vars
         # defined in config_map.yaml
         envFrom:

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe HealthController do
+  describe 'GET #show' do
+    it 'returns 200 OK' do
+      get :show
+      expect(response.body).to eq('healthy')
+      expect(response.status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
Even though we are doing rolling deploys, it seems that traffic is being served
to the pods before Rails has booted. So this is still resulting in downtime.

By exposing an endpoint for the readiness probe to test, we can ensure that the application
will be ready to serve traffic by the time it is registered with the load balancer.