### PR TITLE
Resque exceptions

### DIFF
--- a/app/jobs/process_submission_job.rb
+++ b/app/jobs/process_submission_job.rb
@@ -67,17 +67,6 @@ class ProcessSubmissionJob < ApplicationJob
     body_part_content
   end
 
-  def on_retryable_exception(error)
-    logger.warn "RETRYABLE EXCEPTION! @submission #{@submission.inspect}"
-    @submission.fail!(retryable: true) if @submission
-    super
-  end
-
-  def on_non_retryable_exception(error)
-    @submission.fail!(retryable: false) if @submission
-    super
-  end
-
   private
 
   # returns an array of Attachment objects

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -11,3 +11,10 @@ begin
 rescue URI::InvalidURIError
   puts "could not parse a valid Redis URI from #{url} - falling back to file log"
 end
+
+require 'resque/failure/multiple'
+require 'resque/failure/redis'
+require 'resque/failure/sentry'
+
+Resque::Failure::Multiple.classes = [Resque::Failure::Redis, Resque::Failure::Sentry]
+Resque::Failure.backend = Resque::Failure::Multiple

--- a/lib/resque/failure/sentry.rb
+++ b/lib/resque/failure/sentry.rb
@@ -1,0 +1,9 @@
+module Resque
+  module Failure
+    class Sentry < Base
+      def save
+        Raven.capture_exception(exception)
+      end
+    end
+  end
+end

--- a/spec/lib/resque/failure/sentry_spec.rb
+++ b/spec/lib/resque/failure/sentry_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Resque::Failure::Sentry do
+  describe '#save' do
+    let(:exception) do
+      StandardError.new('foo')
+    end
+
+    let(:worker) { double('worker') }
+    let(:queue) { double('queue') }
+    let(:payload) { double('payload') }
+
+    subject do
+      described_class.new(exception, worker, queue, payload)
+    end
+
+    it 'notifies sentry' do
+      expect(Raven).to receive(:capture_exception).with(exception)
+
+      subject.save
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,9 +44,9 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -54,6 +54,7 @@ RSpec.configure do |config|
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
 
+=begin
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.


### PR DESCRIPTION
- When a job fails in Resque it carries on the current behaviour where the job is moved to the failed queue in Redis
- We slot in an additional handler that also sends the exception to sentry