### PR TITLE
Remove logging of senstive data from AmazonSESAdapter

### DIFF
--- a/app/services/adapters/amazon_ses_adapter.rb
+++ b/app/services/adapters/amazon_ses_adapter.rb
@@ -3,10 +3,6 @@ module Adapters
     # creds automatically retrieved from
     # ENV['AWS_ACCESS_KEY_ID'] and ENV['AWS_SECRET_ACCESS_KEY']
     def self.send_mail( opts = {} )
-      Rails.logger.debug "send_mail to #{opts[:to]}"
-      Rails.logger.debug "raw_message: #{opts[:raw_message]}"
-      Rails.logger.debug "send_mail from #{opts[:from]}"
-
       client.send_raw_email({
         destinations: [ opts[:to] ],
         raw_message: {


### PR DESCRIPTION
This logging exposes PII and looks like it was only for debug purposes.