### PR TITLE
Don't log all attributes in HasStatusViaJob

### DIFF
--- a/app/models/concerns/has_status_via_job.rb
+++ b/app/models/concerns/has_status_via_job.rb
@@ -24,7 +24,6 @@ module Concerns
         logger.info "in fail!, retryable: #{retryable}"
         status = retryable ? STATUS[:failed_retryable] : STATUS[:failed_non_retryable]
         update_attributes(status: status, completed_at: Time.now)
-        logger.info "attributes updated to #{attributes}"
       end
     end
   end


### PR DESCRIPTION
We were logging the entire attributes of each `HasStatusViaJob` object which includes PII like emails, eg:
```
value_before_type_cast: '[{"from":"some.one@example.com","to":"destination@example.com",
```

It looks like this logging was just for debugging so its been removed.