### PR TITLE
Bump Puma version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.5.1'
 
 gem 'rails', '~> 5.2.2.1'
 gem 'pg', '>= 0.18', '< 2.0'
-gem 'puma', '~> 3.11'
+gem 'puma', '~> 4.0'
 gem 'aws-sdk-ses', '~> 1.16.0'
 gem 'jwt'
 gem 'resque'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
-    puma (3.12.0)
+    puma (4.0.0)
+      nio4r (~> 2.0)
     rack (2.0.6)
     rack-protection (2.0.4)
       rack
@@ -314,7 +315,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   phantomjs
   poltergeist
-  puma (~> 3.11)
+  puma (~> 4.0)
   rails (~> 5.2.2.1)
   resque
   rspec-rails (>= 3.5.0)


### PR DESCRIPTION
We are investigating memory leaks and when looking at the running processes on
the box, we can see that Puma is using more memory than anything else.

There is an issue about this on Github:
https://github.com/puma/puma/issues/1600

This may not be the cause but worth seeing if this stops the memory leaks.

<img width="1425" alt="Screenshot 2019-07-11 at 12 44 32" src="https://user-images.githubusercontent.com/1215147/61048471-d1869680-a3d9-11e9-9f5b-d8ef2685df2a.png">
