### PR TITLE
Delayed job metrics

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,37 +1,24 @@
 class MetricsController < ActionController::Base
-  PrometheusResqueGauges = [
-    { name: :resque_jobs_pending,
-      lookup: :pending,
-      docstring: 'Number of pending jobs' },
-    { name: :resque_jobs_processed,
-      lookup: :processed,
-      docstring: 'Number of jobs processed' },
-    { name: :resque_job_queues,
-      lookup: :queues,
-      docstring: ' Number of job queues' },
-    { name: :resque_workers,
-      lookup: :workers,
-      docstring: 'Number of workers' },
-    { name: :resque_workers_working,
-      lookup: :working,
-      docstring: 'Number of workers working' },
-    { name: :resque_jobs_failed,
-      lookup: :failed,
-      docstring: 'Number of jobs failed' }
-  ].freeze
-
   def show
-    respond_to do |f|
-      f.text
-      f.html { render template: 'metrics/show.text' }
-    end
+    response.headers['version'] = '0.0.4'
+    @stats = delayed_jobs_stats
   end
 
   private
 
-  def prometheus_resque_gauges
-    PrometheusResqueGauges
-  end
+  def delayed_jobs_stats
+    pending_job_count = Delayed::Job.where('attempts = 0').count
+    failed_job_count = Delayed::Job.where('attempts > 0').count
 
-  helper_method :prometheus_resque_gauges
+    [
+      { name: :resque_jobs_pending,
+        docstring: 'Number of pending jobs',
+        value: pending_job_count
+      },
+      { name: :resque_jobs_failed,
+        docstring: 'Number of jobs failed',
+        value: failed_job_count
+      }
+    ]
+  end
 end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -11,11 +11,11 @@ class MetricsController < ActionController::Base
     failed_job_count = Delayed::Job.where('attempts > 0').count
 
     [
-      { name: :resque_jobs_pending,
+      { name: :delayed_jobs_pending,
         docstring: 'Number of pending jobs',
         value: pending_job_count
       },
-      { name: :resque_jobs_failed,
+      { name: :delayed_jobs_failed,
         docstring: 'Number of jobs failed',
         value: failed_job_count
       }

--- a/app/views/metrics/show.text.erb
+++ b/app/views/metrics/show.text.erb
@@ -1,5 +1,5 @@
-<% prometheus_resque_gauges.each do |gauge| %>
-# TYPE <%= gauge[:name] %> gauge
-# HELP <%= gauge[:name] %> <%= gauge[:docstring] %>
-<%= gauge[:name] %> <%= gauge[:lookup] %>
+<% @stats.each do |gauge| %>
+# TYPE <%= gauge.fetch(:name) %> gauge
+# HELP <%= gauge.fetch(:name) %> <%= gauge.fetch(:docstring) %>
+<%= gauge.fetch(:name) %> <%= gauge.fetch(:value) %>
 <% end %>

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe MetricsController do
       end
 
       it 'shows pending jobs' do
-        expected_result = '# TYPE resque_jobs_pending gauge
-# HELP resque_jobs_pending Number of pending jobs
-resque_jobs_pending 1'
+        expected_result = '# TYPE delayed_jobs_pending gauge
+# HELP delayed_jobs_pending Number of pending jobs
+delayed_jobs_pending 1'
         expect(response.body).to include(expected_result)
       end
     end
@@ -27,9 +27,9 @@ resque_jobs_pending 1'
       end
 
       it 'shows failed jobs' do
-        expected_result = '# TYPE resque_jobs_failed gauge
-# HELP resque_jobs_failed Number of jobs failed
-resque_jobs_failed 1'
+        expected_result = '# TYPE delayed_jobs_failed gauge
+# HELP delayed_jobs_failed Number of jobs failed
+delayed_jobs_failed 1'
 
         expect(response.body).to include(expected_result)
       end

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -35,10 +35,10 @@ resque_jobs_failed 1'
       end
     end
 
-    context 'Given an HTML response' do
+    describe 'Response headers' do
       before { get :show, format: 'text' }
 
-      it 'adds the prometheus version header' do
+      it 'adds the prometheus version' do
         expect(response.headers['version']).to eq('0.0.4')
       end
     end

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -1,41 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe MetricsController do
-  xdescribe 'GET #show' do
+  describe 'GET #show' do
     render_views
 
-    let(:info) do
-      {
-        pending: 1,
-        processed: 2,
-        queues: 3,
-        workers: 4,
-        working: 5,
-        failed: 6
-      }
+    let(:job) { Delayed::Job.create! }
+
+    context 'given a pending job' do
+      before do
+        job.update(attempts: 0)
+        get :show, format: 'text'
+      end
+
+      it 'shows pending jobs' do
+        expected_result = '# TYPE resque_jobs_pending gauge
+# HELP resque_jobs_pending Number of pending jobs
+resque_jobs_pending 1'
+        expect(response.body).to include(expected_result)
+      end
     end
 
-    before :each do
-      allow(Resque).to receive(:info).and_return(info)
+    context 'given a failed job' do
+      before do
+        job.update(attempts: 1)
+        get :show, format: 'text'
+      end
+
+      it 'shows failed jobs' do
+        expected_result = '# TYPE resque_jobs_failed gauge
+# HELP resque_jobs_failed Number of jobs failed
+resque_jobs_failed 1'
+
+        expect(response.body).to include(expected_result)
+      end
     end
 
-    it 'works' do
-      get :show, format: 'text'
-      expect(response).to be_successful
-    end
+    context 'Given an HTML response' do
+      before { get :show, format: 'text' }
 
-    it 'works' do
-      get :show, format: 'html'
-      expect(response).to be_successful
-    end
-
-    it 'returns prometheus metrics' do
-      get :show, format: 'text'
-      body = response.body
-
-      expect(body).to include('# TYPE resque_jobs_pending gauge')
-      expect(body).to include('# HELP resque_jobs_pending Number of pending jobs')
-      expect(body).to include('resque_jobs_pending 1')
+      it 'adds the prometheus version header' do
+        expect(response.headers['version']).to eq('0.0.4')
+      end
     end
   end
 end


### PR DESCRIPTION
This will make the job queue statistics visible in Grafana.
There are less metrics than Resque provided out of the box but having visibility
over pending and failed jobs will be enough to recognise if something is going
wrong.