### PR TITLE
Use response.set_header for metrics text format

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,6 +1,6 @@
 class MetricsController < ActionController::Base
   def show
-    response.content_type = 'text/plain; version=0.0.4'
+    response.set_header('Content-Type', 'text/plain; version=0.0.4')
     @stats = delayed_jobs_stats
 
     render 'metrics/show.text'

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -39,7 +39,7 @@ delayed_jobs_failed 1'
       before { get :show, format: 'html' }
 
       it 'adds the prometheus version' do
-        expect(response.headers['Content-Type']).to eq('text/plain; version=0.0.4; charset=utf-8')
+        expect(response.headers['Content-Type']).to eq('text/plain; version=0.0.4')
       end
     end
   end


### PR DESCRIPTION
Using response.content_type adds utf-8 data which seems to break the
Grafana request