### PR TITLE
Fix local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@ deploy/
 scripts/
 tmp/
 !tmp/.keep
+tmp/pids/server.pid
 node_modules/
 package.json
 package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 DOCKER_COMPOSE = docker-compose -f docker-compose.yml
 
+ifndef CIRCLE_SHA1
+	DOCKER_COMPOSE += -f docker-compose.development.yml
+endif
+
 dev:
 	echo "TODO: Remove dev function call from deploy-utils"
 

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -4,3 +4,5 @@ services:
   app:
     volumes:
       - '.:/app'
+    ports:
+      - '8080:3000'


### PR DESCRIPTION
The API wasn't booting because the server.pid file was being copied into the
container.  Ensure this is being ignored when creating the image.

Re-instate development docker-compose, and assign to port 8080.