### PR TITLE
Match validation in the Runner

### DIFF
--- a/app/models/sms.rb
+++ b/app/models/sms.rb
@@ -4,7 +4,7 @@ class Sms
   attr_accessor :to, :body, :template_name, :extra_personalisation
 
   validates :template_name, inclusion: { in: TemplateMappingService::Sms::ALL }
-  validates :to, format: { with: /\A\+{0,1}\d{9,16}\z/ }
+  validates :to, format: { with: /\A(\+\d\d\s*){0,1}(\d(\s|-){0,1}){8,15}\d\z/ }
 
   def extra_personalisation
     @extra_personalisation || {}

--- a/spec/models/sms_spec.rb
+++ b/spec/models/sms_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe Sms do
 
           subject.to = "447123456789"
           expect(subject).to be_valid
+
+          subject.to = "+44 0712 3456789"
+          expect(subject).to be_valid
+
+          subject.to = "01632 960 001"
+          expect(subject).to be_valid
+
+          subject.to = "07700 900 982"
+          expect(subject).to be_valid
         end
       end
     end


### PR DESCRIPTION
We are allowing spaces in phone numbers to provide a better user experience