### PR TITLE
Send the correct headers for Runner callback

### DIFF
--- a/app/services/adapters/runner_callback.rb
+++ b/app/services/adapters/runner_callback.rb
@@ -4,15 +4,14 @@ module Adapters
     class ClientRequestError < StandardError
     end
 
-    def initialize(url:)
+    def initialize(url:, token:)
       @url = url
+      @token = token
     end
 
     def fetch_full_submission
-      response = Typhoeus::Request.new(
-          url,
-          method: :get,
-      ).run
+      response = Typhoeus.get(url, headers: headers)
+
       unless response.success?
         raise ClientRequestError, "request for #{url} returned response status of: #{response.code}"
       end
@@ -21,6 +20,10 @@ module Adapters
 
     private
 
-    attr_reader :url
+    def headers
+      { 'x-encrypted-user-id-and-token' => token }
+    end
+
+    attr_reader :url, :token
   end
 end

--- a/app/services/process_submission_service.rb
+++ b/app/services/process_submission_service.rb
@@ -7,19 +7,18 @@ class ProcessSubmissionService
     @submission_id = submission_id
   end
 
-  JSON_DESTINATION_PLACEHOLDER = 'https://example.com/json_destination_placeholder'.freeze
-
   def perform
     submission.update_status(:processing)
     submission.responses = []
 
+    token = submission.encrypted_user_id_and_token
     submission.submission_details.each do |submission_detail|
       submission_detail = submission_detail.symbolize_keys
 
       if submission_detail.fetch(:type) == 'json'
         JsonWebhookService.new(
-            runner_callback_adapter: Adapters::RunnerCallback.new(url: submission_detail.fetch(:url)),
-            webhook_destination_adapter: Adapters::WebhookDestination.new(url: JSON_DESTINATION_PLACEHOLDER)
+          runner_callback_adapter: Adapters::RunnerCallback.new(url: submission_detail.fetch(:data_url), token: token),
+          webhook_destination_adapter: Adapters::WebhookDestination.new(url: submission_detail.fetch(:url))
         ).execute
       end
     end

--- a/spec/services/adapters/runner_callback_spec.rb
+++ b/spec/services/adapters/runner_callback_spec.rb
@@ -10,8 +10,12 @@ describe Adapters::RunnerCallback do
     "http://www.example.com/#{SecureRandom.uuid}"
   end
 
+  let(:expected_headers) do
+    { 'x-encrypted-user-id-and-token' => 'some-token' }
+  end
+
   subject do
-    described_class.new(url: expected_url)
+    described_class.new(url: expected_url, token: 'some-token')
   end
 
   it 'returns the submission json when given a url' do
@@ -19,7 +23,7 @@ describe Adapters::RunnerCallback do
 
     expect(subject.fetch_full_submission).to eq(response)
 
-    expect(WebMock).to have_requested(:get, expected_url).once
+    expect(WebMock).to have_requested(:get, expected_url).with(headers: expected_headers).once
   end
 
   it 'throws exception if not 200 response' do

--- a/spec/services/process_submission_service_spec.rb
+++ b/spec/services/process_submission_service_spec.rb
@@ -108,7 +108,8 @@ describe ProcessSubmissionService do
       let(:json_submission) do
         {
           'type' => 'json',
-          'url': runner_callback_url,
+          'url': json_destination_url,
+          'data_url': runner_callback_url,
           'attachments' => []
         }
       end


### PR DESCRIPTION
We require authentication between the submitter and the runner.
Include the token in the header when calling the JSON output route.