### PR TITLE
Remove unused dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'tzinfo-data'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'capybara', '>= 2.15', '< 4.0'
   gem 'rspec-rails', '>= 3.8.0'
   gem 'rswag-specs'
 end
@@ -34,11 +33,6 @@ end
 group :test do
   gem 'database_cleaner'
   gem 'factory_bot_rails', '~> 5.0'
-  gem 'faker'
-  gem 'poltergeist'
-  gem 'phantomjs'
-  gem 'selenium-webdriver'
-  gem 'shoulda-matchers', '~> 4.1'
   gem 'simplecov'
   gem 'simplecov-console', require: false
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,17 +62,6 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
-    capybara (3.28.0)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.5)
-      xpath (~> 3.2)
-    childprocess (1.0.1)
-      rake (< 13.0)
-    cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
@@ -95,8 +84,6 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
-    faker (2.1.2)
-      i18n (>= 0.8)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
@@ -160,11 +147,6 @@ GEM
     notifications-ruby-client (4.0.0)
       jwt (>= 1.5, < 3)
     pg (1.1.4)
-    phantomjs (2.1.1.0)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -202,7 +184,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    regexp_parser (1.6.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -234,16 +215,10 @@ GEM
       actionpack (>= 3.1, < 6.0)
       railties (>= 3.1, < 6.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.3)
     safe_yaml (1.0.5)
-    selenium-webdriver (3.142.3)
-      childprocess (>= 0.5, < 2.0)
-      rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.11.0)
       faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
-    shoulda-matchers (4.1.2)
-      activesupport (>= 4.2.0)
     simplecov (0.17.0)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -279,8 +254,6 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -289,12 +262,10 @@ DEPENDENCIES
   aws-sdk-ses (~> 1.25.0)
   bootsnap (>= 1.1.0)
   byebug
-  capybara (>= 2.15, < 4.0)
   daemons
   database_cleaner
   delayed_job_active_record (~> 4.1.3)
   factory_bot_rails (~> 5.0)
-  faker
   guard-rspec
   guard-shell
   jwt
@@ -302,17 +273,13 @@ DEPENDENCIES
   mime-types
   notifications-ruby-client
   pg (>= 0.18, < 2.0)
-  phantomjs
-  poltergeist
   puma (~> 4.1)
   rails (~> 5.2.3)
   rspec-rails (>= 3.8.0)
   rswag-api
   rswag-specs
   rswag-ui
-  selenium-webdriver
   sentry-raven
-  shoulda-matchers (~> 4.1)
   simplecov
   simplecov-console
   timecop

--- a/Guardfile
+++ b/Guardfile
@@ -60,10 +60,6 @@ guard :rspec, cmd: "bundle exec rspec",
   watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
   watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
 
-  # Capybara features specs
-  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
-  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
-
   # Turnip features and steps
   watch(%r{^spec/acceptance/(.+)\.feature$})
   watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|


### PR DESCRIPTION
Removes:
- faker
- poltergeist
- phantomjs
- selenium webdriver
- shoulda matchers
- capybara

None of these are being used and we are continually upgrading them with dependabot.