### PR TITLE
set sentry env

### DIFF
--- a/deploy/fb-submitter-chart/templates/deployment.yaml
+++ b/deploy/fb-submitter-chart/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
           - configMapRef:
               name: fb-submitter-env-{{ .Values.environmentName }}
         env:
+          - name: SENTRY_CURRENT_ENV
+            value: {{ .Values.environmentName }}
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:
@@ -115,6 +117,8 @@ spec:
           - configMapRef:
               name: fb-submitter-env-{{ .Values.environmentName }}
         env:
+          - name: SENTRY_CURRENT_ENV
+            value: {{ .Values.environmentName }}
           # third-party access keys etc, defined in secrets.yml
           - name: AWS_ACCESS_KEY_ID
             valueFrom:


### PR DESCRIPTION
Currently, all errors in staging and production are sent to sentry under the 'production' env.

This makes it hard to figure out if a bug has been fixed in staging etc

This pr sets the override env var for sentry so we can tell the difference

Reference docs: docs.sentry.io/clients/ruby/config

(would like to do this to other projects if merged )