### PR TITLE
Make encryption keys in specs different

### DIFF
--- a/spec/requests/json_output_spec.rb
+++ b/spec/requests/json_output_spec.rb
@@ -46,8 +46,8 @@ describe 'Submits JSON given a JSON submission type', type: :request do
         filename: 'form1.pdf'
       }, {
         url: 'example.com/2',
-        encryption_key: 'bar1',
-        encryption_iv: 'baz1',
+        encryption_key: 'bar2',
+        encryption_iv: 'baz2',
         mimetype: 'application/pdf',
         filename: 'form2.pdf'
       }


### PR DESCRIPTION
I noticed while writing documentation that the keys and iv's in this spec were the same. In reality they are unique per file and this is a very important point.

As specs often serve as docs for us developers, I've updated it to be more accurate.