### PR TITLE
disable Style/SymbolProc

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,9 @@ Metrics/LineLength:
 Style/Next:
   Enabled: false
 
+Style/SymbolProc:
+  Enabled: false
+
 Metrics/BlockLength:
   ExcludedMethods: ['describe', 'context', 'let']
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -106,11 +106,3 @@ RSpec/SubjectStub:
   Exclude:
     - 'spec/services/download_service_spec.rb'
     - 'spec/services/process_submission_service_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: IgnoredMethods.
-# IgnoredMethods: respond_to, define_method
-Style/SymbolProc:
-  Exclude:
-    - 'app/services/process_submission_service.rb'


### PR DESCRIPTION
this rule makes blocks harder to read i.e 
Current
```ruby
      body_part_content[type] = File.open(body_part_map[url]) { |f| f.read }

```
if it was left enabled it would autocorrect to
```ruby
      body_part_content[type] = File.open(body_part_map[url], &:read)
```