### PR TITLE
Service and Adapter for requesting a PDF to be generated

### DIFF
--- a/app/services/adapters/pdf_generator.rb
+++ b/app/services/adapters/pdf_generator.rb
@@ -1,0 +1,26 @@
+module Adapters
+  class PdfGenerator
+    class ClientRequestError < StandardError
+    end
+    def initialize(url:, token:)
+      @url = url
+      @token = token
+    end
+
+    def generate_pdf(submission:)
+      response = Typhoeus.post(url, body: submission, headers: headers)
+
+      raise ClientRequestError, "request for #{url} returned response status of: #{response.code}" unless response.success?
+
+      response.body
+    end
+
+    private
+
+    def headers
+      { 'x-encrypted-user-id-and-token' => token }
+    end
+
+    attr_reader :url, :token
+  end
+end

--- a/app/services/generate_pdf.rb
+++ b/app/services/generate_pdf.rb
@@ -1,0 +1,13 @@
+class GeneratePdf
+  def initialize(pdf_generator_gateway:)
+    @pdf_generator_gateway = pdf_generator_gateway
+  end
+
+  def execute(payload)
+    pdf_generator_gateway.generate_pdf(submission: payload)
+  end
+
+  private
+
+  attr_reader :pdf_generator_gateway
+end

--- a/spec/services/adapters/pdf_generator_spec.rb
+++ b/spec/services/adapters/pdf_generator_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+describe Adapters::PdfGenerator do
+  subject(:adapter) do
+    described_class.new(url: expected_url, token: 'some-token')
+  end
+
+  let(:submission) do
+    {
+      submission_id: 1,
+      other_stuff: []
+    }
+  end
+
+  let(:response) do
+    'a-lot-of-pdf-contents'
+  end
+
+  let(:expected_url) do
+    "http://www.pdf-generator.com/#{SecureRandom.uuid}"
+  end
+
+  let(:expected_headers) do
+    { 'x-encrypted-user-id-and-token' => 'some-token' }
+  end
+
+  before do
+    stub_request(:post, expected_url).to_return(status: 200, body: response, headers: {})
+  end
+
+  it 'requests a generated PDF' do
+    adapter.generate_pdf(submission: submission)
+    expect(WebMock).to have_requested(:post, expected_url).with(headers: expected_headers).once
+  end
+
+  it 'returns the pdf file from the response' do
+    expect(adapter.generate_pdf(submission: submission)).to eq(response)
+  end
+
+  context 'when a 500 is returned' do
+    before do
+      stub_request(:post, expected_url).to_return(status: 500)
+    end
+
+    it 'throws an exception' do
+      expect do
+        adapter.generate_pdf(submission: {})
+      end.to raise_error(Adapters::PdfGenerator::ClientRequestError)
+    end
+  end
+end

--- a/spec/services/generate_pdf_spec.rb
+++ b/spec/services/generate_pdf_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../app/services/generate_pdf'
+
+describe GeneratePdf do
+  subject(:pdf_service) { described_class.new(pdf_generator_gateway: gateway) }
+
+  let(:gateway) { instance_double('Adapters::PdfGenerator', generate_pdf: 'some pdf contents') }
+  let(:payload) { { some: 'payload' } }
+
+  context 'when requesting a pdf with a submission' do
+    it 'calls generate_pdf on the gateway' do
+      pdf_service.execute(payload)
+      expect(gateway).to have_received(:generate_pdf).with(submission: payload)
+    end
+
+    it 'returns the result of the API call' do
+      result = pdf_service.execute(payload)
+      expect(result).to eq('some pdf contents')
+    end
+  end
+end


### PR DESCRIPTION
These classes are unused right now but will be used in the
ProcessSubmissionService to get the attachments used to send the confirmation email.