### PR TITLE
Noop PDF attachments method

### DIFF
--- a/app/value_objects/pdf_submission_detail.rb
+++ b/app/value_objects/pdf_submission_detail.rb
@@ -1,3 +1,7 @@
 class PdfSubmissionDetail
   def initialize(params = {}); end
+
+  def attachments
+    []
+  end
 end


### PR DESCRIPTION
PDF attachments will be treated differently to Email submission detail objects.
Implement and noop the attachments method for now.

We can decide whether we want to keep this existing meta-programming pattern and
have everything use it, or remove this pattern all toghether down the line.