### PR TITLE
Test PDF submission alongside other types

### DIFF
--- a/spec/services/process_submission_service_spec.rb
+++ b/spec/services/process_submission_service_spec.rb
@@ -60,6 +60,36 @@ describe ProcessSubmissionService do
       }
     end
 
+    let(:pdf_submission) do
+      {
+        type: 'pdf',
+        submission: {
+          submission_id: '1786c427-246e-4bb7-90b9-a2e6cfae003f',
+          pdf_heading: 'Best form on the web',
+          pdf_subheading: '(Optional) Some section heading',
+          sections: [
+            {
+              heading: 'Whats your name',
+              summary_heading: 'WIP',
+              questions: []
+            }, {
+              heading: '',
+              summary_heading: '',
+              questions: [
+                {
+                  label: 'First name',
+                  answer: 'Bob'
+                }, {
+                  label: 'Last name',
+                  answer: 'Smith'
+                }
+              ]
+            }
+          ]
+        }
+      }
+    end
+
     let(:processed_attachments) do
       [
         Attachment.new(
@@ -99,7 +129,7 @@ describe ProcessSubmissionService do
       allow(subject).to receive(:retrieve_mail_body_parts).and_return(body_part_content)
     end
 
-    context 'with a mix of email and json submissions' do
+    context 'with a mix of email, pdf and json submissions' do
       let(:runner_callback_url) { 'https://example.com/runner_frontend_callback' }
       let(:json_destination_url) { 'https://example.com/json_destination_placeholder' }
 
@@ -134,7 +164,8 @@ describe ProcessSubmissionService do
             email_submission,
             json_submission,
             json_submission,
-            json_submission
+            json_submission,
+            pdf_submission
           ], status: 'queued'
         )
       end
@@ -149,6 +180,8 @@ describe ProcessSubmissionService do
       before do
         stub_request(:get, runner_callback_url).with(headers: headers).to_return(status: 200, body: '{"foo": "bar"}')
         stub_request(:post, json_destination_url).with(headers: headers).to_return(status: 200)
+        stub_request(:post, 'http://pdf-generator.com/')
+          .with(body: pdf_submission.fetch(:submission).to_json, headers: headers).to_return(status: 200)
       end
 
       it 'dispatches 1 email for each submission email attachment' do
@@ -543,64 +576,6 @@ describe ProcessSubmissionService do
                                                          subject: 'mail subject {id-of-submission} [2/2]',
                                                          to: 'destination@example.com')
 
-        subject.perform
-      end
-    end
-
-    context 'when generating a PDF' do
-      before do
-        stub_request(:post, 'http://pdf-generator.com/')
-          .with(
-            body: submission_details.fetch(:submission) .to_json,
-            headers: {
-              'Expect' => '',
-              'User-Agent' => 'Typhoeus - https://github.com/typhoeus/typhoeus',
-              'X-Access-Token' => 'encrypted_user_id_and_token'
-            }
-          )
-          .to_return(status: 200, body: '', headers: {})
-      end
-
-      let(:submission) do
-        Submission.create!(
-          encrypted_user_id_and_token: 'encrypted_user_id_and_token',
-          status: 'queued',
-          submission_details: [submission_details],
-          service_slug: 'service-slug'
-        )
-      end
-
-      let(:submission_details) do
-        {
-          type: 'pdf',
-          submission: {
-            submission_id: '1786c427-246e-4bb7-90b9-a2e6cfae003f',
-            pdf_heading: 'Best form on the web',
-            pdf_subheading: '(Optional) Some section heading',
-            sections: [
-              {
-                heading: 'Whats your name',
-                summary_heading: 'WIP',
-                questions: []
-              }, {
-                heading: '',
-                summary_heading: '',
-                questions: [
-                  {
-                    label: 'First name',
-                    answer: 'Bob'
-                  }, {
-                    label: 'Last name',
-                    answer: 'Smith'
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      end
-
-      it 'requests for a PDF to be generated' do
         subject.perform
       end
     end


### PR DESCRIPTION
Some edge cases weren't being caught by just running type pdf submission on it's
own.

We will never get just a pdf submission detail, it will be alongside type
'email', and 'json'.  Change the test to reflect this.