### PR TITLE
unpin dev dependancy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 group :development do
   gem 'guard-rspec', require: false
   gem 'guard-shell'
-  gem 'listen',
+  gem 'listen'
   gem 'rswag-api'
   gem 'rswag-ui'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 group :development do
   gem 'guard-rspec', require: false
   gem 'guard-shell'
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'listen',
   gem 'rswag-api'
   gem 'rswag-ui'
 end


### PR DESCRIPTION
no need to lock this if its only used in dev. Removes dependabot noise too