### PR TITLE
Use new runner payload for PDFs

### DIFF
--- a/app/services/save_temp_pdf.rb
+++ b/app/services/save_temp_pdf.rb
@@ -8,7 +8,7 @@ class SaveTempPdf
     tmp_pdf = tmp_file_gateway.new([file_name, '.pdf'])
     pdf_contents = generate_pdf_content_service.execute
 
-    tmp_pdf.write(pdf_contents)
+    tmp_pdf.write(pdf_contents.force_encoding('UTF-8'))
     tmp_pdf.rewind
 
     tmp_pdf.path

--- a/app/value_objects/attachment.rb
+++ b/app/value_objects/attachment.rb
@@ -1,12 +1,14 @@
+# rubocop:disable Metrics/ParameterLists
 class Attachment
   attr_reader :type, :filename, :url, :mimetype, :path
 
-  def initialize(type:, filename:, url:, mimetype:, path:)
+  def initialize(type:, filename:, url:, mimetype:, path:, pdf_data: {})
     @type = type
     @filename = filename
     @url = url
     @mimetype = mimetype
     @path = path
+    @pdf_data = pdf_data
   end
 
   def filename_with_extension
@@ -17,3 +19,4 @@ class Attachment
     "#{raw_filename}.#{ext}"
   end
 end
+# rubocop:enable Metrics/ParameterLists


### PR DESCRIPTION
PDF data needs to be scoped to the recipient (user or team)
The payload has changed to do this.

This makes it easier to process this data in the Runner.