### PR TITLE
Fix Tempfile object being deleted early

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,7 +287,7 @@ DEPENDENCIES
   guard-shell
   jwe (~> 0.4.0)
   jwt
-  listen (>= 3.0.5, < 3.2)
+  listen
   mime-types
   notifications-ruby-client
   pg (>= 0.18, < 2.0)

--- a/app/services/process_submission_service.rb
+++ b/app/services/process_submission_service.rb
@@ -113,10 +113,7 @@ class ProcessSubmissionService
   end
 
   def attachments(mail)
-    @generated_attachments ||= generate_attachments(mail.attachments.map(&:with_indifferent_access))
-  end
-
-  def generate_attachments(attachments)
+    attachments = mail.attachments.map(&:with_indifferent_access)
     attachment_objects = AttachmentParserService.new(attachments: attachments).execute
 
     attachments.each_with_index do |value, index|
@@ -128,6 +125,7 @@ class ProcessSubmissionService
     end
     attachment_objects
   end
+
 
   def download_attachments
     @url_file_map ||= DownloadService.download_in_parallel(

--- a/app/services/process_submission_service.rb
+++ b/app/services/process_submission_service.rb
@@ -115,7 +115,7 @@ class ProcessSubmissionService # rubocop:disable Metrics/ClassLength
 
     attachments.each_with_index do |value, index|
       if value[:pdf_data]
-        attachment_objects[index].file = generate_pdf({submission: value[:pdf_data]}, @submission_id)
+        attachment_objects[index].file = generate_pdf({ submission: value[:pdf_data] }, @submission_id)
       else
         attachment_objects[index].path = download_attachments[attachment_objects[index].url]
       end
@@ -123,9 +123,8 @@ class ProcessSubmissionService # rubocop:disable Metrics/ClassLength
     attachment_objects
   end
 
-
   def download_attachments
-    @url_file_map ||= DownloadService.download_in_parallel(
+    @download_attachments ||= DownloadService.download_in_parallel(
       urls: unique_attachment_urls,
       headers: headers
     )

--- a/app/services/save_temp_pdf.rb
+++ b/app/services/save_temp_pdf.rb
@@ -12,7 +12,7 @@ class SaveTempPdf
     tmp_pdf.write(pdf_contents)
     tmp_pdf.rewind
 
-    tmp_pdf.path
+    tmp_pdf
   end
 
   private

--- a/app/value_objects/attachment.rb
+++ b/app/value_objects/attachment.rb
@@ -1,14 +1,17 @@
-# rubocop:disable Metrics/ParameterLists
 class Attachment
-  attr_reader :type, :filename, :url, :mimetype, :path
+  attr_accessor :type, :filename, :url, :mimetype, :path
 
-  def initialize(type:, filename:, url:, mimetype:, path:, pdf_data: {})
+  def initialize(type:, filename:, url:, mimetype:, path:)
     @type = type
     @filename = filename
     @url = url
     @mimetype = mimetype
     @path = path
-    @pdf_data = pdf_data
+  end
+
+  def file=(file)
+    @file = file # hold a reference as TempFiles are erased when garbage collected
+    @path = file.path
   end
 
   def filename_with_extension
@@ -19,4 +22,3 @@ class Attachment
     "#{raw_filename}.#{ext}"
   end
 end
-# rubocop:enable Metrics/ParameterLists

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -77,6 +77,10 @@ describe 'UserData API', type: :request do
       stub_request(:get, 'http://my-service.formbuilder-services-test:3000/api/submitter/pdf/default/7a9a5124-0ab2-43f1-b345-0685fced5705.pdf').to_return(status: 200, body: '', headers: {})
 
       allow(Aws::SES::Client).to receive(:new).with(region: 'eu-west-1').and_return(stub_aws)
+
+      # PDF Generator stubs
+      stub_request(:get, 'http://fake_service_token_cache_root_url/service/my-service').to_return(status: 200, body: { token: '123' }.to_json)
+      stub_request(:post, 'http://pdf-generator.com/v1/pdfs').with(body: '{"question_1":"answer 1","question_2":"answer 2"}').to_return(status: 200, body: 'pdf binary goes here')
     end
 
     after do
@@ -114,11 +118,21 @@ describe 'UserData API', type: :request do
                   'text/plain' => '/some/plain.txt'
                 },
                 attachments: [
-                  {
+                  { # this is a deprecated version of pdf attachments
                     type: 'output',
                     mimetype: 'application/pdf',
                     url: '/api/submitter/pdf/default/7a9a5124-0ab2-43f1-b345-0685fced5705.pdf',
                     filename: 'form'
+                  },
+                  { # this is the new version of pdf attachments
+                    type: 'output',
+                    mimetype: 'application/pdf',
+                    url: '/api/submitter/pdf/default/7a9a5124-0ab2-43f1-b345-0685fced5705.pdf',
+                    filename: 'form',
+                    pdf_data: {
+                      question_1: 'answer 1',
+                      question_2: 'answer 2'
+                    }
                   },
                   {
                     type: 'filestore',
@@ -145,6 +159,12 @@ describe 'UserData API', type: :request do
           end
 
           context 'when the request is successful' do
+            let(:raw_messages) do
+              stub_aws.api_requests.map do |request|
+                request[:params][:raw_message][:data]
+              end
+            end
+
             it 'downloads email attachments' do
               post_request
               expect(WebMock).to have_requested(:get, %r{fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/ioj/user/a239313d-4d2d-4a16-b5ef-69d6e8e53e86/}).times(2)
@@ -157,14 +177,21 @@ describe 'UserData API', type: :request do
 
             it 'downloads email body parts' do
               post_request
-              # TODO: this may be requested more than needede
-              expect(WebMock).to have_requested(:get, 'http://my-service.formbuilder-services-test:3000/some/plain.txt').times(3)
-              expect(WebMock).to have_requested(:get, 'http://my-service.formbuilder-services-test:3000/some/html').times(3)
+              # TODO: this may be requested more than needed
+              expect(WebMock).to have_requested(:get, 'http://my-service.formbuilder-services-test:3000/some/plain.txt').times(4)
+              expect(WebMock).to have_requested(:get, 'http://my-service.formbuilder-services-test:3000/some/html').times(4)
             end
 
-            it 'sends 3 emails' do
+            it 'sends 4 emails' do
               post_request
-              expect(stub_aws.api_requests.size).to eq(3)
+              expect(stub_aws.api_requests.size).to eq(4)
+            end
+
+            it 'email contains downloaded attachment' do
+              post_request
+
+              file_ccontent = Base64.encode64('pdf binary goes here')
+              expect(raw_messages.join).to include(file_ccontent)
             end
 
             it 'creates a submission record' do

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -80,7 +80,7 @@ describe 'UserData API', type: :request do
 
       # PDF Generator stubs
       stub_request(:get, 'http://fake_service_token_cache_root_url/service/my-service').to_return(status: 200, body: { token: '123' }.to_json)
-      stub_request(:post, 'http://pdf-generator.com/v1/pdfs').with(body: '{"question_1":"answer 1","question_2":"answer 2"}').to_return(status: 200, body: 'pdf binary goes here')
+      stub_request(:post, 'http://pdf-generator.com/v1/pdfs').with(body: '{"question_1":"answer 1","question_2":"answer 2"}').to_return(status: 200, body: pdf_file_content)
     end
 
     after do
@@ -90,6 +90,8 @@ describe 'UserData API', type: :request do
     let(:stub_aws) do
       Aws::SES::Client.new(region: 'eu-west-1', stub_responses: true)
     end
+
+    let(:pdf_file_content) { 'pdf binary goes here' }
 
     describe 'to /submission' do
       let(:url) { '/submission' }
@@ -190,7 +192,7 @@ describe 'UserData API', type: :request do
             it 'email contains downloaded attachment' do
               post_request
 
-              file_ccontent = Base64.encode64('pdf binary goes here')
+              file_ccontent = Base64.encode64(pdf_file_content)
               expect(raw_messages.join).to include(file_ccontent)
             end
 

--- a/spec/services/attachment_parser_service_spec.rb
+++ b/spec/services/attachment_parser_service_spec.rb
@@ -18,7 +18,10 @@ describe AttachmentParserService do
           type: 'output',
           mimetype: 'applcation/pdf',
           filename: 'foo.pdf',
-          url: 'https://example.com'
+          url: 'https://example.com',
+          pdf_data: {
+            question: 'answer'
+          }
         }
       ]
     end

--- a/spec/services/save_temp_pdf_spec.rb
+++ b/spec/services/save_temp_pdf_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe SaveTempPdf do
 
   let(:result) { pdf_attachments_service.execute(file_name: '123') }
 
-  it 'returns the temporary file locations of the downloaded pdfs' do
-    expect(result).to match(%r{/tmp\/123(.*).pdf})
+  it 'returns the temporary file ' do
+    expect(result).to be_a(Tempfile)
   end
 
   it 'writes the contents of the PDF to the temporary file' do

--- a/spec/value_objects/attachment_spec.rb
+++ b/spec/value_objects/attachment_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../app/value_objects/attachment'
+require 'tempfile'
+
+RSpec.describe Attachment do
+  subject(:attachment_instance) { described_class.new(type: 'output', url: nil, filename: 'somthing.pdf', mimetype: 'application/pdf', path: nil) }
+
+  let(:tempfile) { Tempfile.new }
+
+  it 'can hold pdf file' do
+    attachment = attachment_instance.file = tempfile
+    expect(attachment.path).to eq(tempfile.path)
+  end
+end


### PR DESCRIPTION
Tempfile deletes the file on disk when the Tempfile object is garbage collected. So instead we pass around the object around to use it.