### PR TITLE
Don't authenticate in Development

### DIFF
--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -57,11 +57,7 @@ module Concerns
     end
 
     def disable_jwt?
-      swagger || false
-    end
-
-    def swagger
-      Rails.env.development? && request.referrer.include?('api-docs')
+      Rails.env.development?
     end
   end
 end


### PR DESCRIPTION
JWT authentication through the Token Service Cache is coupled to Kubernetes.

To use this app in local stack testing we need to disable JWT authentication
until the implementation can be made more generic.