### PR TITLE
add small delay to process submission job

### DIFF
--- a/app/controllers/submission_controller.rb
+++ b/app/controllers/submission_controller.rb
@@ -6,7 +6,8 @@ class SubmissionController < ApplicationController
     @submission.save!
 
     Delayed::Job.enqueue(
-      ProcessSubmissionService.new(submission_id: @submission.id)
+      ProcessSubmissionService.new(submission_id: @submission.id),
+      run_at: 3.seconds.from_now
     )
 
     render status: :created

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -224,6 +224,13 @@ describe 'UserData API', type: :request do
               expect(Delayed::Job).to receive(:enqueue)
               post_request
             end
+
+            it 'creates a Job with short delay to prevent filestore race conditions' do
+              Timecop.freeze(Time.now) do
+                expect(Delayed::Job).to receive(:enqueue).with(anything, run_at: 3.seconds.from_now)
+                post_request
+              end
+            end
             # rubocop:enable RSpec/MessageSpies
 
             describe 'the response' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,7 +110,7 @@ SimpleCov.start do
   add_filter '/spec/'
 end
 
-SimpleCov.minimum_coverage 93
+SimpleCov.minimum_coverage 98
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::Console


### PR DESCRIPTION
this is to prevent a possible race condition
where files in user file store are not ready when processing submission
this seems to have happened when pdf generation was extracted out of runner