### PR TITLE
Disable JWT authentication in development

### DIFF
--- a/app/services/process_submission_service.rb
+++ b/app/services/process_submission_service.rb
@@ -141,13 +141,24 @@ class ProcessSubmissionService # rubocop:disable Metrics/ClassLength
   end
 
   def pdf_gateway(service_slug)
-    token = JwtAuthService.new(
+    Adapters::PdfApi.new(
+      root_url: ENV.fetch('PDF_GENERATOR_ROOT_URL'),
+      token: authentication_token(service_slug)
+    )
+  end
+
+  def authentication_token(service_slug)
+    return if disable_jwt?
+
+    JwtAuthService.new(
       service_token_cache: Adapters::ServiceTokenCacheClient.new(
         root_url: ENV.fetch('SERVICE_TOKEN_CACHE_ROOT_URL')
       ),
       service_slug: service_slug
     ).execute
+  end
 
-    Adapters::PdfApi.new(root_url: ENV.fetch('PDF_GENERATOR_ROOT_URL'), token: token)
+  def disable_jwt?
+    Rails.env.development?
   end
 end


### PR DESCRIPTION
To generate a PDF we first authenticate by going through the Service Token Cache.
Don't do this in development when doing local stack testing.

Long term plan is to include JWT authentication in local stack testing but that
will require some changes to decouple it from Kubernetes.