### PR TITLE
Allow overriding the Runner callback URL

### DIFF
--- a/app/services/adapters/service_url_resolver.rb
+++ b/app/services/adapters/service_url_resolver.rb
@@ -23,7 +23,7 @@ module Adapters
     private
 
     def internal_host(service_slug, environment_slug)
-      "#{service_slug}.formbuilder-services-#{environment_slug}"
+      ENV['RUNNER_CALLBACK_URL_OVERRIDE'] || "#{service_slug}.formbuilder-services-#{environment_slug}"
     end
   end
 end

--- a/spec/services/adapters/service_url_resolver_spec.rb
+++ b/spec/services/adapters/service_url_resolver_spec.rb
@@ -31,6 +31,17 @@ describe Adapters::ServiceUrlResolver do
       it 'returns the resolved URL' do
         expect(subject.ensure_absolute_url(url)).to eq('http://my-service.formbuilder-services-dev:3000/a/relative/url')
       end
+
+      context 'when the RUNNER_CALLBACK_URL_OVERRIDE is set' do
+        before do
+          allow(ENV).to receive(:[])
+          allow(ENV).to receive(:[]).with('RUNNER_CALLBACK_URL_OVERRIDE').and_return('some-runner-callback')
+        end
+
+        it 'uses the RUNNER_CALLBACK_URL_OVERRIDE' do
+          expect(subject.ensure_absolute_url(url)).to eq('http://some-runner-callback:3000/a/relative/url')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
By setting this environment variable, it will take presedence over the hardcoded
URL.  This is required to call back to the Runner for local stack testing.