### PR TITLE
Add Mock Aws SES Adapter

### DIFF
--- a/app/services/adapters/mock_amazon_ses_adapter.rb
+++ b/app/services/adapters/mock_amazon_ses_adapter.rb
@@ -1,0 +1,7 @@
+module Adapters
+  class MockAmazonSESAdapter
+    def self.send_mail(opts = {})
+      Typhoeus.post(ENV.fetch('EMAIL_ENDPOINT_OVERRIDE'), body: opts)
+    end
+  end
+end

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -12,6 +12,10 @@ class EmailService
   end
 
   def self.adapter
+    if ENV['EMAIL_ENDPOINT_OVERRIDE'].present?
+      return Adapters::MockAmazonSESAdapter
+    end
+
     Adapters::AmazonSESAdapter
   end
 end

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -5,6 +5,16 @@ describe EmailService do
     it 'is Adapters::AmazonSESAdapter' do
       expect(described_class.adapter).to eq(Adapters::AmazonSESAdapter)
     end
+
+    context 'when overriding the email endpoint' do
+      before do
+        allow(ENV).to receive(:[]).with('EMAIL_ENDPOINT_OVERRIDE').and_return('http://some-custom-email-api.com')
+      end
+
+      it 'uses the mock email adapter' do
+        expect(described_class.adapter).to eq(Adapters::MockAmazonSESAdapter)
+      end
+    end
   end
 
   describe '.sanitised_params' do


### PR DESCRIPTION
When testing through the local stack, we need a way to observe the email and
submission contents that were sent over.

Swap out SESAdapter for a mock implementation so that this can be asserted on.

This should be the final change to enable us to test these APIs with local stack testing.