### PR TITLE
Remove last mentions of email callback

### DIFF
--- a/spec/services/process_submission_service_spec.rb
+++ b/spec/services/process_submission_service_spec.rb
@@ -45,9 +45,6 @@ describe ProcessSubmissionService do
         'to' => 'destination@example.com',
         'subject' => 'mail subject',
         'type' => 'email',
-        'body_parts' => {
-          'text/plain' => 'https://tools.ietf.org/rfc/rfc2324.txt'
-        },
         'attachments' => attachments
       }
     end


### PR DESCRIPTION
Last cleanup of code that uses the old email callback url that lived under `body_parts` in the submission payload.