### PR TITLE
Fix shape of JSON payload

### DIFF
--- a/app/services/json_webhook_service.rb
+++ b/app/services/json_webhook_service.rb
@@ -4,26 +4,18 @@ class JsonWebhookService
     @webhook_destination_adapter = webhook_destination_adapter
   end
 
-  def execute(submission:, service_slug:)
+  def execute(user_answers:, service_slug:, submission_id:)
     webhook_destination_adapter.send_webhook(
-      body: build_payload(
-        submission: submission,
-        service_slug: service_slug,
-        attachments: webhook_attachment_fetcher.execute
-      )
+      body: {
+        "serviceSlug": service_slug,
+        "submissionId": submission_id,
+        "submissionAnswers": user_answers,
+        "attachments": webhook_attachment_fetcher.execute
+      }.to_json
     )
   end
 
   private
 
   attr_reader :webhook_destination_adapter, :webhook_attachment_fetcher
-
-  def build_payload(service_slug:, attachments:, submission:)
-    {
-      "serviceSlug": service_slug,
-      "submissionId": submission.fetch('submission_id', nil),
-      "submissionAnswers": submission.except('submissionId'),
-      "attachments": attachments
-    }.to_json
-  end
 end

--- a/app/services/process_submission_service.rb
+++ b/app/services/process_submission_service.rb
@@ -22,8 +22,8 @@ class ProcessSubmissionService # rubocop:disable  Metrics/ClassLength
           webhook_destination_adapter: Adapters::JweWebhookDestination.new(
             url: action.fetch(:url),
             key: action.fetch(:encryption_key)
-          )
-        ).execute(submission: payload_service.submission, service_slug: submission.service_slug)
+          ),
+        ).execute(user_answers: payload_service.user_answers_map, service_slug: submission.service_slug, submission_id: payload_service.submission_id)
       else
         Rails.logger.warn "Unknown action type '#{action.fetch(:type)}' for submission id #{submission.id}"
       end

--- a/app/services/submission_payload_service.rb
+++ b/app/services/submission_payload_service.rb
@@ -1,13 +1,14 @@
 require 'active_support/core_ext/hash'
 
 class SubmissionPayloadService
-  attr_reader :attachments, :actions, :submission
+  attr_reader :attachments, :actions, :submission, :submission_id
 
   def initialize(payload)
     payload = payload.with_indifferent_access
     @attachments = payload.fetch(:attachments)
     @actions = payload.fetch(:actions)
     @submission = payload.fetch(:submission)
+    @submission_id = payload.fetch(:submission).fetch('submission_id')
   end
 
   def user_answers_map

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -1,13 +1,14 @@
 FactoryBot.define do
+  submission_id = SecureRandom.uuid
+
   factory :submission do
     status { Submission::STATUS[:queued] }
     service_slug { 'service-slug' }
     encrypted_user_id_and_token { 'some token' }
-
     transient do
       actions { [] }
       attachments { [] }
-      submission { {} }
+      submission { { 'submission_id' => submission_id } }
     end
 
     payload { { actions: actions, submission: submission, attachments: attachments } }
@@ -20,7 +21,7 @@ FactoryBot.define do
             url: 'https://my-custom-endpoint/ap/v1/foo',
             encryption_key: 'jdwjdwjwdhwhdh73',
             data_url: 'this-url-should-no-longer-be-called-or-used',
-            submissionId: SecureRandom.uuid,
+            submissionId: submission_id,
             user_answers: {
               first_name: 'bob',
               last_name: 'madly',

--- a/spec/requests/json_output_spec.rb
+++ b/spec/requests/json_output_spec.rb
@@ -88,7 +88,7 @@ describe 'Submits JSON given a JSON submission type', type: :request do
     {
       "serviceSlug": service_slug,
       "submissionId": submission_id,
-      "submissionAnswers": submission.except(:submissionId),
+      "submissionAnswers": expected_submission_answers,
       attachments: expected_attachments
     }.to_json
   end

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -143,7 +143,7 @@ describe 'UserData API', type: :request do
               encrypted_user_id_and_token: encrypted_user_id_and_token,
               submission_details: submission_details,
               actions: [], # TODO: not yet used for email
-              submission: {},  # TODO: not yet used for email
+              submission: { 'submission_id' => SecureRandom.uuid  },  # TODO: not yet used for email
               attachments: []  # TODO: not yet used for email
             }
           end

--- a/spec/services/json_webhook_service_spec.rb
+++ b/spec/services/json_webhook_service_spec.rb
@@ -62,22 +62,18 @@ describe JsonWebhookService do
   before do
     allow(webhook_destination_adapter).to receive(:send_webhook)
     allow(webhook_attachment_fetcher).to receive(:execute).and_return(attachments)
+    service.execute(
+      user_answers: user_answers, service_slug: submission.service_slug, submission_id: submission.payload[:submission_id]
+    )
   end
 
   it 'modifies and sends the submission to the destination' do
-    service.execute(submission: user_answers, service_slug: submission.service_slug)
-
     expect(webhook_destination_adapter).to have_received(:send_webhook)
       .with(body: json_payload)
       .once
   end
 
-  it 'calls fetch_full_submission' do
-    service.execute(submission: user_answers, service_slug: submission.service_slug)
-  end
-
   it 'calls the webhook_attachment_fetcher' do
-    service.execute(submission: user_answers, service_slug: submission.service_slug)
     expect(webhook_attachment_fetcher).to have_received(:execute).once
   end
 end


### PR DESCRIPTION
We were getting a Sentry error due to a regression where the JSON output had changed shape. In order to fix this, we need to pass in the correct `user_answers_map` object, plus the `submission_id`.

Also fixed:
- Mismatched IDs in the `Submission` factory and specs. The `submission_id` and `Submission.id` are different. The `submission_id` should also be the same within the submission payload.