### PR TITLE
Create email output service

### DIFF
--- a/app/services/email_output_service.rb
+++ b/app/services/email_output_service.rb
@@ -1,0 +1,49 @@
+class EmailOutputService
+  def initialize(email_service:)
+    @email_service = email_service
+  end
+
+  def execute(action:, attachments:, pdf_attachment:)
+    email_attachments = []
+
+    if action.fetch(:include_attachments) == true
+      email_attachments = email_attachments.concat attachments
+    end
+    if action.fetch(:include_pdf) == true
+      email_attachments << pdf_attachment
+    end
+
+    send_emails(action, email_attachments)
+  end
+
+  private
+
+  def send_emails(action, email_attachments)
+    loop do
+      send_single_email(
+        action: action,
+        attachment: email_attachments.pop || []
+      )
+
+      break if email_attachments.size <= 0
+    end
+  end
+
+  def send_single_email(action:, attachment:)
+    email_service.send_mail(
+      from: action.fetch(:from),
+      to: action.fetch(:to),
+      subject: action.fetch(:subject),
+      body_parts: email_body_parts(action.fetch(:email_body)),
+      attachments: attachment
+    )
+  end
+
+  def email_body_parts(email_body)
+    {
+      'text/plain': email_body
+    }
+  end
+
+  attr_reader :email_service
+end

--- a/app/services/email_output_service.rb
+++ b/app/services/email_output_service.rb
@@ -3,7 +3,7 @@ class EmailOutputService
     @email_service = email_service
   end
 
-  def execute(action:, attachments:, pdf_attachment:, submission_id:)
+  def execute(submission_id:, action:, attachments:, pdf_attachment:)
     email_attachments = []
 
     if action.fetch(:include_attachments) == true
@@ -16,8 +16,13 @@ class EmailOutputService
     if email_attachments.empty?
       send_single_email(
         action: action,
-        subject: subject(subject: action.fetch(:subject), current_email: 1, number_of_emails: 1, submission_id: submission_id),
-        attachments: []
+        attachments: [],
+        subject: subject(
+          subject: action.fetch(:subject),
+          current_email: 1,
+          number_of_emails: 1,
+          submission_id: submission_id
+        )
       )
     else
       send_emails_with_attachments(action, email_attachments, submission_id: submission_id)
@@ -30,8 +35,13 @@ class EmailOutputService
     email_attachments.each_with_index do |email_attachment, index|
       send_single_email(
         action: action,
-        subject: subject(subject: action.fetch(:subject), current_email: index + 1, number_of_emails: email_attachments.size, submission_id: submission_id),
-        attachments: [email_attachment]
+        attachments: [email_attachment],
+        subject: subject(
+          subject: action.fetch(:subject),
+          current_email: index + 1,
+          number_of_emails: email_attachments.size,
+          submission_id: submission_id
+        )
       )
     end
   end

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -48,7 +48,7 @@ describe EmailOutputService do
                                                                  attachments: []).once
   end
 
-  context 'when a include_attachments is true' do
+  context 'when a user uploaded attachments are required' do
     let(:include_attachments) { true }
 
     it 'sends a separate email for each attachment' do
@@ -62,7 +62,7 @@ describe EmailOutputService do
     end
   end
 
-  context 'when a include_pdf is true' do
+  context 'when a user answers pdf is needed' do
     let(:include_pdf) { true }
 
     it 'sends an email with the generated pdf as a attachment' do
@@ -70,7 +70,7 @@ describe EmailOutputService do
     end
   end
 
-  context 'when both include_attachments and include_pdf is true' do
+  context 'when both uploaded attachments and answers pdf are required' do
     let(:include_attachments) { true }
     let(:include_pdf) { true }
 

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -37,13 +37,13 @@ describe EmailOutputService do
   before do
     allow(email_service_mock).to receive(:send_mail)
 
-    service.execute(action: email_action, attachments: attachments, pdf_attachment: pdf_attachment)
+    service.execute(action: email_action, attachments: attachments, pdf_attachment: pdf_attachment, submission_id: 'an-id-2323')
   end
 
   it 'execute sends an email' do
     expect(email_service_mock).to have_received(:send_mail).with(to: 'bob.admin@digital.justice.gov.uk',
                                                                  from: 'form-builder@digital.justice.gov.uk',
-                                                                 subject: 'Complain about a court or tribunal submission',
+                                                                 subject: 'Complain about a court or tribunal submission {an-id-2323} [1/1]',
                                                                  body_parts: { 'text/plain': 'Please find an application attached' },
                                                                  attachments: []).once
   end
@@ -52,13 +52,13 @@ describe EmailOutputService do
     let(:include_attachments) { true }
 
     it 'sends a separate email for each attachment' do
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: attachments[0])).once
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: attachments[1])).once
+      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: [attachments[0]])).once
+      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: [attachments[1]])).once
     end
 
     it 'the subject is numbered by how many seperte emails there are' do
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission')).once
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission')).once
+      expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]')).once
+      expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]')).once
     end
   end
 
@@ -66,7 +66,7 @@ describe EmailOutputService do
     let(:include_pdf) { true }
 
     it 'sends an email with the generated pdf as a attachment' do
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: pdf_attachment)).once
+      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: [pdf_attachment])).once
     end
   end
 

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -1,0 +1,81 @@
+require_relative '../../app/services/email_output_service'
+require_relative '../../app/services/email_service'
+require_relative '../../app/value_objects/attachment'
+
+describe EmailOutputService do
+  subject(:service) { described_class.new(email_service: email_service_mock) }
+
+  let(:email_service_mock) { class_double(EmailService) }
+
+  let(:email_action) do
+    {
+      recipientType: 'team',
+      type: 'email',
+      from: 'form-builder@digital.justice.gov.uk',
+      to: 'bob.admin@digital.justice.gov.uk',
+      subject: 'Complain about a court or tribunal submission',
+      email_body: 'Please find an application attached',
+      include_pdf: include_pdf,
+      include_attachments: include_attachments
+    }
+  end
+
+  let(:include_pdf) { false }
+  let(:include_attachments) { false }
+
+  let(:attachments) do
+    [
+      Attachment.new(type: 'output', url: 'example.com/foo', mimetype: 'application/pdf', filename: 'form1', path: nil),
+      Attachment.new(type: 'output', url: 'example.com/bar', mimetype: 'application/json', filename: 'form2', path: nil)
+    ]
+  end
+
+  let(:pdf_attachment) do
+    Attachment.new(type: 'output', url: nil, mimetype: 'application/pdf', filename: 'a generated pff', path: nil)
+  end
+
+  before do
+    allow(email_service_mock).to receive(:send_mail)
+
+    service.execute(action: email_action, attachments: attachments, pdf_attachment: pdf_attachment)
+  end
+
+  it 'execute sends an email' do
+    expect(email_service_mock).to have_received(:send_mail).with(to: 'bob.admin@digital.justice.gov.uk',
+                                                                 from: 'form-builder@digital.justice.gov.uk',
+                                                                 subject: 'Complain about a court or tribunal submission',
+                                                                 body_parts: { 'text/plain': 'Please find an application attached' },
+                                                                 attachments: []).once
+  end
+
+  context 'when a include_attachments is true' do
+    let(:include_attachments) { true }
+
+    it 'sends a separate email for each attachment' do
+      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: attachments[0])).once
+      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: attachments[1])).once
+    end
+
+    it 'the subject is numbered by how many seperte emails there are' do
+      expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission')).once
+      expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission')).once
+    end
+  end
+
+  context 'when a include_pdf is true' do
+    let(:include_pdf) { true }
+
+    it 'sends an email with the generated pdf as a attachment' do
+      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: pdf_attachment)).once
+    end
+  end
+
+  context 'when both include_attachments and include_pdf is true' do
+    let(:include_attachments) { true }
+    let(:include_pdf) { true }
+
+    it 'sends a separate email for each attachment' do
+      expect(email_service_mock).to have_received(:send_mail).exactly(3).times
+    end
+  end
+end


### PR DESCRIPTION
The email output service will encapsulate sending emails in the submitter api.

Currently this is done in a number of services such as the process submission service 