### PR TITLE
Duplicate and change download service to handle new payload

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -58,6 +58,7 @@ RSpec/ExampleLength:
   Exclude:
     - 'spec/services/adapters/user_file_store_spec.rb'
     - 'spec/services/download_service_spec.rb'
+    - 'spec/services/new_download_service_spec.rb'
     - 'spec/services/process_submission_service_spec.rb'
 
 # Offense count: 30
@@ -66,6 +67,7 @@ RSpec/ExampleLength:
 RSpec/MessageSpies:
   Exclude:
     - 'spec/services/download_service_spec.rb'
+    - 'spec/services/new_download_service_spec.rb'
     - 'spec/services/process_submission_service_spec.rb'
 
 # Offense count: 11
@@ -92,4 +94,5 @@ RSpec/NestedGroups:
 RSpec/SubjectStub:
   Exclude:
     - 'spec/services/download_service_spec.rb'
+    - 'spec/services/new_download_service_spec.rb'
     - 'spec/services/process_submission_service_spec.rb'

--- a/app/services/new_download_service.rb
+++ b/app/services/new_download_service.rb
@@ -30,13 +30,6 @@ class NewDownloadService
     { 'x-encrypted-user-id-and-token' => token }
   end
 
-  def download(url:, target_dir: nil, headers: {})
-    path = file_path_for_download(url: url, target_dir: target_dir)
-    request = construct_request(url: url, file_path: path, headers: headers)
-    request.run
-    path
-  end
-
   def construct_request(url:, file_path:, headers: {})
     request = Typhoeus::Request.new(url, followlocation: true, headers: headers)
     request.on_headers do |response|

--- a/app/services/new_download_service.rb
+++ b/app/services/new_download_service.rb
@@ -1,0 +1,66 @@
+class NewDownloadService
+  attr_reader :attachments, :target_dir, :token
+
+  def initialize(attachments:, target_dir: nil, token:)
+    @attachments = attachments
+    @target_dir = target_dir
+    @token = token
+  end
+
+  def download_in_parallel
+    actual_dir = target_dir || Dir.mktmpdir
+    results = {}
+
+    hydra = Typhoeus::Hydra.hydra
+
+    attachments.each do |attachment|
+      url = attachment.fetch('url')
+      file = file_path_for_download(url: url, target_dir: actual_dir)
+      request = construct_request(url: url, file_path: file, headers: headers)
+      results[url] = file
+      hydra.queue(request)
+    end
+    hydra.run
+    results
+  end
+
+  private
+
+  def headers
+    { 'x-encrypted-user-id-and-token' => token }
+  end
+
+  def download(url:, target_dir: nil, headers: {})
+    path = file_path_for_download(url: url, target_dir: target_dir)
+    request = construct_request(url: url, file_path: path, headers: headers)
+    request.run
+    path
+  end
+
+  def construct_request(url:, file_path:, headers: {})
+    request = Typhoeus::Request.new(url, followlocation: true, headers: headers)
+    request.on_headers do |response|
+      if response.code != 200
+        raise "Request failed (#{response.code}: #{response.return_code} #{request.url})"
+      end
+    end
+    open_file = File.open(file_path, 'wb')
+    # writing a chunk at a time is way more efficient for large files
+    # as Typhoeus won't then try to hold the whole body in RAM
+    request.on_body do |chunk|
+      open_file.write(chunk)
+    end
+    request.on_complete do |response|
+      open_file.close
+      raise "Request failed (#{response.code}: #{response.return_code} #{request.url})" if response.code != 200
+      # Note that response.body is "", cause it's been cleared as we go
+    end
+    request
+  end
+
+  def file_path_for_download(url:, target_dir: nil)
+    actual_dir = target_dir || Dir.mktmpdir
+    filename = File.basename(URI.parse(url).path)
+    File.join(actual_dir, filename)
+  end
+end

--- a/spec/services/new_download_service_spec.rb
+++ b/spec/services/new_download_service_spec.rb
@@ -16,13 +16,7 @@ describe NewDownloadService do
   let(:target_dir) { '/my/target/dir' }
 
   describe '#download_in_parallel' do
-    before do
-      allow(Typhoeus::Hydra).to receive(:hydra).and_return(mock_hydra)
-      allow(mock_hydra).to receive(:run).and_return('run result')
-      allow(mock_hydra).to receive(:queue).and_return('queue result')
-    end
-
-    subject do
+    subject(:downloader) do
       described_class.new(attachments: attachments, target_dir: target_dir, token: token)
     end
 
@@ -30,9 +24,12 @@ describe NewDownloadService do
     let(:mock_request) { instance_double(Typhoeus::Request) }
 
     before do
-      allow(subject).to receive(:construct_request).and_return(mock_request)
+      allow(Typhoeus::Hydra).to receive(:hydra).and_return(mock_hydra)
+      allow(mock_hydra).to receive(:run).and_return('run result')
+      allow(mock_hydra).to receive(:queue).and_return('queue result')
+      allow(downloader).to receive(:construct_request).and_return(mock_request)
       allow(mock_request).to receive(:run).and_return('run result')
-      allow(subject).to receive(:file_path_for_download).and_return(path + '/file.ext')
+      allow(downloader).to receive(:file_path_for_download).and_return(path + '/file.ext')
     end
 
     context 'when no target_dir is given' do
@@ -44,12 +41,12 @@ describe NewDownloadService do
 
       it 'makes a temp dir' do
         expect(Dir).to receive(:mktmpdir)
-        subject.download_in_parallel
+        downloader.download_in_parallel
       end
     end
 
     context 'when a target_dir is given' do
-      subject do
+      subject(:downloader) do
         described_class.new(attachments: attachments, target_dir: target_dir, token: token)
       end
 
@@ -57,12 +54,12 @@ describe NewDownloadService do
 
       it 'does not make a temp dir' do
         expect(Dir).not_to receive(:mktmpdir)
-        subject.download_in_parallel
+        downloader.download_in_parallel
       end
     end
 
     context 'with an array of urls' do
-      subject do
+      subject(:downloader) do
         described_class.new(attachments: attachments, target_dir: path, token: token)
       end
 
@@ -88,30 +85,30 @@ describe NewDownloadService do
       end
 
       before do
-        allow(subject).to receive(:file_path_for_download).with(url: url1, target_dir: path).and_return('/tmp/file1')
-        allow(subject).to receive(:file_path_for_download).with(url: url2, target_dir: path).and_return('/tmp/file2')
-        allow(subject).to receive(:construct_request).with(url: url1, file_path: '/tmp/file1', headers: headers).and_return(mock_request_1)
-        allow(subject).to receive(:construct_request).with(url: url2, file_path: '/tmp/file2', headers: headers).and_return(mock_request_2)
+        allow(downloader).to receive(:file_path_for_download).with(url: url1, target_dir: path).and_return('/tmp/file1')
+        allow(downloader).to receive(:file_path_for_download).with(url: url2, target_dir: path).and_return('/tmp/file2')
+        allow(downloader).to receive(:construct_request).with(url: url1, file_path: '/tmp/file1', headers: headers).and_return(mock_request_1)
+        allow(downloader).to receive(:construct_request).with(url: url2, file_path: '/tmp/file2', headers: headers).and_return(mock_request_2)
       end
 
       describe 'for each url' do
         it 'gets the file_path_for_download' do
-          expect(subject).to receive(:file_path_for_download).with(url: url1, target_dir: path).and_return('/tmp/file1')
-          expect(subject).to receive(:file_path_for_download).with(url: url2, target_dir: path).and_return('/tmp/file2')
-          subject.download_in_parallel
+          expect(downloader).to receive(:file_path_for_download).with(url: url1, target_dir: path).and_return('/tmp/file1')
+          expect(downloader).to receive(:file_path_for_download).with(url: url2, target_dir: path).and_return('/tmp/file2')
+          downloader.download_in_parallel
         end
 
         it 'constructs a request, passing the url and file path for download' do
-          expect(subject).to receive(:construct_request).with(url: url1, file_path: '/tmp/file1', headers: headers)
-          expect(subject).to receive(:construct_request).with(url: url2, file_path: '/tmp/file2', headers: headers)
-          subject.download_in_parallel
+          expect(downloader).to receive(:construct_request).with(url: url1, file_path: '/tmp/file1', headers: headers)
+          expect(downloader).to receive(:construct_request).with(url: url2, file_path: '/tmp/file2', headers: headers)
+          downloader.download_in_parallel
         end
 
         it 'includes x-access-token header with JWT' do
           time = Time.new(2019, 1, 1, 13, 57).utc
 
           Timecop.freeze(time) do
-            allow(subject).to receive(:construct_request).and_call_original
+            allow(downloader).to receive(:construct_request).and_call_original
 
             expected_url1 = 'https://example.com/service/some-service/user/some-user/fingerprint'
             expected_url2 = 'https://another.domain/some/otherfile.ext'
@@ -120,24 +117,24 @@ describe NewDownloadService do
             expect(Typhoeus::Request).to receive(:new).with(expected_url1, followlocation: true, headers: expected_headers).and_return(double.as_null_object)
             expect(Typhoeus::Request).to receive(:new).with(expected_url2, followlocation: true, headers: expected_headers).and_return(double.as_null_object)
 
-            subject.download_in_parallel
+            downloader.download_in_parallel
           end
         end
 
         it 'queues the request' do
           expect(mock_hydra).to receive(:queue).with(mock_request_1)
           expect(mock_hydra).to receive(:queue).with(mock_request_2)
-          subject.download_in_parallel
+          downloader.download_in_parallel
         end
       end
 
       it 'runs the request batch' do
         expect(mock_hydra).to receive(:run)
-        subject.download_in_parallel
+        downloader.download_in_parallel
       end
 
       it 'returns the urls mapped to file paths' do
-        expect(subject.download_in_parallel).to eq(
+        expect(downloader.download_in_parallel).to eq(
           url1 => '/tmp/file1',
           url2 => '/tmp/file2'
         )
@@ -146,12 +143,13 @@ describe NewDownloadService do
   end
 
   context 'when the network request is unsuccessful' do
-    subject do
+    subject(:downloader) do
       described_class.new(attachments: attachments, target_dir: target_dir, token: token)
     end
-    let(:mock_request) { instance_double(Typhoeus::Request, url: "some_url") }
-    let(:good_response) { double(code: 200, return_code: 200) }
-    let(:bad_response) { double(code: 500, return_code: 500) }
+
+    let(:mock_request) { instance_double(Typhoeus::Request, url: 'some_url') }
+    let(:good_response) { instance_double(Typhoeus::Response, code: 200, return_code: 200) }
+    let(:bad_response) { instance_double(Typhoeus::Response, code: 500, return_code: 500) }
 
     context 'when failure is on headers' do
       before do
@@ -160,24 +158,26 @@ describe NewDownloadService do
       end
 
       it 'raises the correct error' do
-        expect { subject.download_in_parallel }.to raise_error(
-          RuntimeError, "Request failed (500: 500 some_url)"
+        expect { downloader.download_in_parallel }.to raise_error(
+          RuntimeError, 'Request failed (500: 500 some_url)'
         )
       end
     end
 
     context 'when failure is on complete' do
+      let(:file) { instance_double(File, write: true, close: true) }
+
       before do
-        allow(File).to receive(:open).and_return(double(write: true, close: true))
+        allow(File).to receive(:open).and_return(file)
         allow(Typhoeus::Request).to receive(:new).and_return(mock_request)
         allow(mock_request).to receive(:on_headers).and_yield(good_response)
-        allow(mock_request).to receive(:on_body).and_yield("")
+        allow(mock_request).to receive(:on_body).and_yield('')
         allow(mock_request).to receive(:on_complete).and_yield(bad_response)
       end
 
       it 'raises the correct error' do
-        expect { subject.download_in_parallel }.to raise_error(
-          RuntimeError, "Request failed (500: 500 some_url)"
+        expect { downloader.download_in_parallel }.to raise_error(
+          RuntimeError, 'Request failed (500: 500 some_url)'
         )
       end
     end

--- a/spec/services/new_download_service_spec.rb
+++ b/spec/services/new_download_service_spec.rb
@@ -1,0 +1,147 @@
+require 'rails_helper'
+
+describe NewDownloadService do
+  let(:url) { 'https://my.domain/some/path/file.ext' }
+  let(:token) { 'sometoken' }
+  let(:headers) { { 'x-encrypted-user-id-and-token' => token } }
+  let(:mock_hydra) { instance_double(Typhoeus::Hydra) }
+  let(:attachments) do
+    [
+      'url' => url,
+      'mimetype' => 'application/pdf',
+      'filename' => 'evidence_one.pdf',
+      'type' => 'filestore'
+    ]
+  end
+  let(:target_dir) { '/my/target/dir' }
+
+  before do
+    allow(Typhoeus::Hydra).to receive(:hydra).and_return(mock_hydra)
+    allow(mock_hydra).to receive(:run).and_return('run result')
+    allow(mock_hydra).to receive(:queue).and_return('queue result')
+  end
+
+  describe '#download_in_parallel' do
+    subject do
+      described_class.new(attachments: attachments, target_dir: target_dir, token: token)
+    end
+
+    let(:path) { '/the/file/path' }
+    let(:mock_request) { instance_double(Typhoeus::Request) }
+
+    before do
+      allow(subject).to receive(:construct_request).and_return(mock_request)
+      allow(mock_request).to receive(:run).and_return('run result')
+      allow(subject).to receive(:file_path_for_download).and_return(path + '/file.ext')
+    end
+
+    context 'when no target_dir is given' do
+      let(:target_dir) { nil }
+
+      before do
+        allow(Dir).to receive(:mktmpdir).and_return('/a/new/temp/dir')
+      end
+
+      it 'makes a temp dir' do
+        expect(Dir).to receive(:mktmpdir)
+        subject.download_in_parallel
+      end
+    end
+
+    context 'when a target_dir is given' do
+      subject do
+        described_class.new(attachments: attachments, target_dir: target_dir, token: token)
+      end
+
+      let(:target_dir) { '/my/tmp/dir' }
+
+      it 'does not make a temp dir' do
+        expect(Dir).not_to receive(:mktmpdir)
+        subject.download_in_parallel
+      end
+    end
+
+    context 'with an array of urls' do
+      subject do
+        described_class.new(attachments: attachments, target_dir: path, token: token)
+      end
+
+      let(:url1) { 'https://example.com/service/some-service/user/some-user/fingerprint' }
+      let(:url2) { 'https://another.domain/some/otherfile.ext' }
+      let(:mock_request_1) { instance_double(Typhoeus::Request) }
+      let(:mock_request_2) { instance_double(Typhoeus::Request) }
+
+      let(:attachments) do
+        [
+          {
+            'url' => url1,
+            'mimetype' => 'application/pdf',
+            'filename' => 'evidence_one.pdf',
+            'type' => 'filestore'
+          }, {
+            'url' => url2,
+            'mimetype' => 'application/pdf',
+            'filename' => 'evidence_two.pdf',
+            'type' => 'filestore'
+          }
+        ]
+      end
+
+      before do
+        allow(subject).to receive(:file_path_for_download).with(url: url1, target_dir: path).and_return('/tmp/file1')
+        allow(subject).to receive(:file_path_for_download).with(url: url2, target_dir: path).and_return('/tmp/file2')
+        allow(subject).to receive(:construct_request).with(url: url1, file_path: '/tmp/file1', headers: headers).and_return(mock_request_1)
+        allow(subject).to receive(:construct_request).with(url: url2, file_path: '/tmp/file2', headers: headers).and_return(mock_request_2)
+      end
+
+      describe 'for each url' do
+        it 'gets the file_path_for_download' do
+          expect(subject).to receive(:file_path_for_download).with(url: url1, target_dir: path).and_return('/tmp/file1')
+          expect(subject).to receive(:file_path_for_download).with(url: url2, target_dir: path).and_return('/tmp/file2')
+          subject.download_in_parallel
+        end
+
+        it 'constructs a request, passing the url and file path for download' do
+          expect(subject).to receive(:construct_request).with(url: url1, file_path: '/tmp/file1', headers: headers)
+          expect(subject).to receive(:construct_request).with(url: url2, file_path: '/tmp/file2', headers: headers)
+          subject.download_in_parallel
+        end
+
+        it 'includes x-access-token header with JWT' do
+          time = Time.new(2019, 1, 1, 13, 57).utc
+
+          Timecop.freeze(time) do
+            allow(subject).to receive(:construct_request).and_call_original
+
+            expected_url1 = 'https://example.com/service/some-service/user/some-user/fingerprint'
+            expected_url2 = 'https://another.domain/some/otherfile.ext'
+            expected_headers = { 'x-encrypted-user-id-and-token' => 'sometoken' }
+
+            expect(Typhoeus::Request).to receive(:new).with(expected_url1, followlocation: true, headers: expected_headers).and_return(double.as_null_object)
+            expect(Typhoeus::Request).to receive(:new).with(expected_url2, followlocation: true, headers: expected_headers).and_return(double.as_null_object)
+
+            subject.download_in_parallel
+          end
+        end
+
+        it 'queues the request' do
+          expect(mock_hydra).to receive(:queue).with(mock_request_1)
+          expect(mock_hydra).to receive(:queue).with(mock_request_2)
+          subject.download_in_parallel
+        end
+      end
+
+      it 'runs the request batch' do
+        expect(mock_hydra).to receive(:run)
+        subject.download_in_parallel
+      end
+
+      it 'returns the urls mapped to file paths' do
+        expect(subject.download_in_parallel).to eq(
+          url1 => '/tmp/file1',
+          url2 => '/tmp/file2'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is step one of moving towards: https://github.com/ministryofjustice/fb-submitter/pull/210/files

This changes the existing download service to take an array of attachments and download them. I've duplicated the file and named it `New` while we migrate. Its a copy and paste of the original service with as few a changes as possible to get it to take the new payload.

This service is a candidate for refactor, perhaps away from Typheus, but that can happen at a later date.

The original service is here: https://github.com/ministryofjustice/fb-submitter/blob/master/app/services/download_service.rb

Original spec: https://github.com/ministryofjustice/fb-submitter/blob/master/spec/services/download_service_spec.rb