### PR TITLE
Remove confusion of submission.id and submission_id

### DIFF
--- a/app/controllers/submission_controller.rb
+++ b/app/controllers/submission_controller.rb
@@ -7,7 +7,7 @@ class SubmissionController < ApplicationController
       )
     )
     Delayed::Job.enqueue(
-      ProcessSubmissionService.new(submission_id: @submission.id),
+      ProcessSubmissionService.new(id: @submission.id),
       run_at: 3.seconds.from_now
     )
 

--- a/spec/controllers/submission_controller_spec.rb
+++ b/spec/controllers/submission_controller_spec.rb
@@ -1,31 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe SubmissionController, type: :controller do
+  let(:params) { { actions: 1, submission: { submission_id: 'abc', else: 1 }, attachments: [1, 2] } }
+
   before do
     request.env['CONTENT_TYPE'] = 'application/json'
     allow_any_instance_of(ApplicationController).to receive(:verify_token!)
   end
 
   it 'creates a submission' do
-    post :create, body: { something: 1 }.to_json
+    post :create, body: params.to_json
 
     expect(Submission.all.count).to eq(1)
   end
 
-  it 'saves the payload into the submission' do
-    payload = { actions: 1, submission: { else: 1 }, attachments: [1, 2] }
-    post :create, body: payload.to_json
+  it 'saves the params into the submission' do
+    post :create, body: params.to_json
 
-    expect(Submission.first.payload).to eq(payload.deep_stringify_keys)
+    expect(Submission.first.payload).to eq(params.deep_stringify_keys)
   end
 
   it 'creates a delayed job' do
-    post :create, body: { something: 1 }.to_json
+    post :create, body: params.to_json
     expect(Delayed::Job.all.count).to eq(1)
   end
 
   it 'marks delayed job as created' do
-    post :create, body: { something: 1 }.to_json
+    post :create, body: params.to_json
     expect(response).to have_http_status(:created)
   end
 end

--- a/spec/services/process_submission_service_spec.rb
+++ b/spec/services/process_submission_service_spec.rb
@@ -5,7 +5,7 @@ require 'webmock/rspec'
 
 describe ProcessSubmissionService do
   subject do
-    described_class.new(submission_id: submission.id)
+    described_class.new(id: submission.id)
   end
 
   let(:submission) do


### PR DESCRIPTION
When processing a submission, the existing code as interchanging th id of the `Submission` object in the submitter db and the `submission_id` that is generated in the Runner and included in the payload to the submitter.

Eg: `Submission.id != Submission.payload["submission"]["submission_id"]`

This PR removes this confusion.