### PR TITLE
Revert "Remove confusion of submission.id and submission_id (#21…

### DIFF
--- a/app/controllers/submission_controller.rb
+++ b/app/controllers/submission_controller.rb
@@ -7,7 +7,7 @@ class SubmissionController < ApplicationController
       )
     )
     Delayed::Job.enqueue(
-      ProcessSubmissionService.new(id: @submission.id),
+      ProcessSubmissionService.new(submission_id: @submission.id),
       run_at: 3.seconds.from_now
     )
 

--- a/app/services/process_submission_service.rb
+++ b/app/services/process_submission_service.rb
@@ -1,7 +1,8 @@
 class ProcessSubmissionService # rubocop:disable  Metrics/ClassLength
-  def initialize(id:)
-    @submission = Submission.find(id)
-    @payload_service = SubmissionPayloadService.new(@submission.payload)
+  attr_reader :submission_id
+
+  def initialize(submission_id:)
+    @submission_id = submission_id
   end
 
   # rubocop:disable Metrics/MethodLength
@@ -9,6 +10,7 @@ class ProcessSubmissionService # rubocop:disable  Metrics/ClassLength
     submission.update_status(:processing)
     submission.responses = []
 
+    payload_service = SubmissionPayloadService.new(submission.payload)
     payload_service.actions.each do |action|
       case action.fetch(:type)
       when 'json'
@@ -38,8 +40,6 @@ class ProcessSubmissionService # rubocop:disable  Metrics/ClassLength
 
   private
 
-  attr_reader :submission, :payload_service
-
   def email_body_parts(email)
     {
       'text/plain' => email.email_body
@@ -64,7 +64,7 @@ class ProcessSubmissionService # rubocop:disable  Metrics/ClassLength
         response = EmailService.send_mail(
           from: mail.from,
           to: mail.to,
-          subject: "#{mail.subject} {#{payload_service.submission_id}} [#{n + 1}/#{number_of_attachments(mail)}]",
+          subject: "#{mail.subject} {#{submission_id}} [#{n + 1}/#{number_of_attachments(mail)}]",
           body_parts: email_body,
           attachments: [a]
         )
@@ -87,6 +87,10 @@ class ProcessSubmissionService # rubocop:disable  Metrics/ClassLength
     urls.compact.sort.uniq
   end
 
+  def submission
+    @submission ||= Submission.find(submission_id)
+  end
+
   def headers
     { 'x-encrypted-user-id-and-token' => submission.encrypted_user_id_and_token }
   end
@@ -97,7 +101,7 @@ class ProcessSubmissionService # rubocop:disable  Metrics/ClassLength
 
     attachments.each_with_index do |value, index|
       if value[:pdf_data]
-        attachment_objects[index].file = generate_pdf({ submission: value[:pdf_data] }, payload_service.submission_id)
+        attachment_objects[index].file = generate_pdf({ submission: value[:pdf_data] }, @submission_id)
       else
         attachment_objects[index].path = download_attachments[attachment_objects[index].url]
       end

--- a/spec/controllers/submission_controller_spec.rb
+++ b/spec/controllers/submission_controller_spec.rb
@@ -1,32 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe SubmissionController, type: :controller do
-  let(:params) { { actions: 1, submission: { submission_id: 'abc', else: 1 }, attachments: [1, 2] } }
-
   before do
     request.env['CONTENT_TYPE'] = 'application/json'
     allow_any_instance_of(ApplicationController).to receive(:verify_token!)
   end
 
   it 'creates a submission' do
-    post :create, body: params.to_json
+    post :create, body: { something: 1 }.to_json
 
     expect(Submission.all.count).to eq(1)
   end
 
-  it 'saves the params into the submission' do
-    post :create, body: params.to_json
+  it 'saves the payload into the submission' do
+    payload = { actions: 1, submission: { else: 1 }, attachments: [1, 2] }
+    post :create, body: payload.to_json
 
-    expect(Submission.first.payload).to eq(params.deep_stringify_keys)
+    expect(Submission.first.payload).to eq(payload.deep_stringify_keys)
   end
 
   it 'creates a delayed job' do
-    post :create, body: params.to_json
+    post :create, body: { something: 1 }.to_json
     expect(Delayed::Job.all.count).to eq(1)
   end
 
   it 'marks delayed job as created' do
-    post :create, body: params.to_json
+    post :create, body: { something: 1 }.to_json
     expect(response).to have_http_status(:created)
   end
 end

--- a/spec/services/process_submission_service_spec.rb
+++ b/spec/services/process_submission_service_spec.rb
@@ -5,7 +5,7 @@ require 'webmock/rspec'
 
 describe ProcessSubmissionService do
   subject do
-    described_class.new(id: submission.id)
+    described_class.new(submission_id: submission.id)
   end
 
   let(:submission) do


### PR DESCRIPTION
This reverts commit 32a3b745

Earlier today when trying to resolve another issue I was unable to rerun a job. due to the flowing error.
`undefined method update_status for nil:NilClass`

After some investigation, my only hypothesis is that that Initialize method is being not used as expected with `Delayed:Job` (its never used in its examples.)

Reverting this for now due to a production issue that looks to have started from this change, with a popper fix later. (i.e executing delayed job using there docs as refrence)