### PR TITLE
Ensure PDF of answers is sent in first email

### DIFF
--- a/app/services/email_output_service.rb
+++ b/app/services/email_output_service.rb
@@ -25,7 +25,7 @@ class EmailOutputService
       email_attachments = email_attachments.concat attachments
     end
     if action.fetch(:include_pdf) == true
-      email_attachments << pdf_attachment
+      email_attachments.prepend(pdf_attachment)
     end
     email_attachments
   end

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -128,14 +128,21 @@ describe 'UserData API', type: :request do
           it 'email contains downloaded attachment' do
             post_request
 
-            file_ccontent = Base64.encode64(pdf_file_content)
-            expect(raw_messages.join).to include(file_ccontent)
+            file_content = Base64.encode64(pdf_file_content)
+            expect(raw_messages.join).to include(file_content)
           end
 
           it 'email contains email body' do
             post_request
 
             expect(raw_messages).to all(include('this is the body of the email'))
+          end
+
+          it 'sends the PDF of answers with the first email' do
+            post_request
+
+            expect(raw_messages.first).to include('1/3')
+            expect(raw_messages.first).to include('-answers.pdf')
           end
 
           it 'creates a submission record' do


### PR DESCRIPTION
A regression of the refactor was that when a submission with both attachments and a PDF was emailed off, the PDF was not being sent in the first email. 

Eg:
- 1 submission, with 2x attachments and 1x PDF of answers
- Results in 3 emails
- The first email (1/3) contained an attachment, as did the second.
- The third email (3/3) contained the PDF of answers.

As the answers are the most important they should be in the first email.