### PR TITLE
Trigger acceptance tests on merge to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,22 @@ jobs:
           name: deploy to live production
           command: './scripts/circleci_deploy.sh live production $KUBE_TOKEN_LIVE_PRODUCTION'
 
+  trigger_acceptance_tests:
+    docker:
+      - image: circleci/ruby:latest
+    steps:
+      - run:
+          name: "Trigger Acceptance Tests"
+          command: "curl -u ${CIRCLE_TOKEN}: -X POST https://circleci.com/api/v2/project/github/ministryofjustice/fb-acceptance-tests/pipeline -H 'Content-Type: application/json' -H 'Accept: application/json'"
+
 workflows:
   version: 2
   test_and_build:
     jobs:
+      - trigger_acceptance_tests:
+          filters:
+            branches:
+              only: master
       - test
       - build_and_deploy_to_test:
           requires:


### PR DESCRIPTION
We will run the acceptance tests whenever any component changes.
This won't block but will alert us if something is broken, so run this before
anything else.