### PR TITLE
Able to attach CSV to emails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ AllCops:
     - db/schema.rb
     - Guardfile
 
+RSpec/NamedSubject:
+  Enabled: false
+
 Style/IfUnlessModifier:
   Enabled: false
 

--- a/app/services/email_output_service.rb
+++ b/app/services/email_output_service.rb
@@ -3,8 +3,11 @@ class EmailOutputService
     @emailer = emailer
   end
 
-  def execute(submission_id:, action:, attachments:, pdf_attachment:)
-    email_attachments = generate_attachments(action: action, attachments: attachments, pdf_attachment: pdf_attachment)
+  def execute(submission_id:, action:, attachments:, pdf_attachment:, csv_attachment:)
+    email_attachments = generate_attachments(action: action,
+                                             attachments: attachments,
+                                             pdf_attachment: pdf_attachment,
+                                             csv_attachment: csv_attachment)
 
     if email_attachments.empty?
       send_single_email(
@@ -18,15 +21,19 @@ class EmailOutputService
 
   private
 
-  def generate_attachments(action:, attachments:, pdf_attachment:)
+  def generate_attachments(action:, attachments:, pdf_attachment:, csv_attachment:)
     email_attachments = []
 
-    if action.fetch(:include_attachments) == true
+    if action.fetch(:include_attachments)
       email_attachments = email_attachments.concat attachments
     end
-    if action.fetch(:include_pdf) == true
+    if action.fetch(:include_csv, false)
+      email_attachments.prepend(csv_attachment)
+    end
+    if action.fetch(:include_pdf)
       email_attachments.prepend(pdf_attachment)
     end
+
     email_attachments
   end
 

--- a/app/services/generate_csv_content.rb
+++ b/app/services/generate_csv_content.rb
@@ -1,0 +1,63 @@
+require 'csv'
+require 'tempfile'
+require_relative '../value_objects/attachment'
+
+class GenerateCsvContent
+  def initialize(payload:)
+    @payload = payload
+  end
+
+  def execute
+    tmp_csv = generate_temp_file
+    generate_attachment_object(tmp_csv)
+  end
+
+  private
+
+  def csv_contents
+    return @csv_contents if @csv_contents
+
+    @csv_contents = []
+    @csv_contents << csv_headers
+    @csv_contents << csv_data
+  end
+
+  def csv_data
+    data = []
+    data << payload[:submission][:serviceSlug]
+    data << payload[:submission][:submission_id]
+    data.concat(payload[:submission][:submissionAnswers].values)
+    data
+  end
+
+  def csv_headers
+    fixed_headers = ['slug', 'submission_id']
+    dynamic_headers = payload[:submission][:submissionAnswers].keys
+
+    fixed_headers + dynamic_headers
+  end
+
+  def generate_temp_file
+    tmp_csv = Tempfile.new
+
+    CSV.open(tmp_csv.path, 'w') do |csv|
+      csv_contents.each do |row|
+        csv << row
+      end
+    end
+
+    tmp_csv.rewind
+    tmp_csv
+  end
+
+  def generate_attachment_object(tmp_csv)
+    attachment = Attachment.new(
+      filename: "#{payload[:submission][:submission_id]}-answers.csv",
+      mimetype: 'text/csv'
+    )
+    attachment.file = tmp_csv
+    attachment
+  end
+
+  attr_reader :payload
+end

--- a/app/services/generate_csv_content.rb
+++ b/app/services/generate_csv_content.rb
@@ -26,7 +26,7 @@ class GenerateCsvContent
     data = []
 
     data << payload_service.submission_id
-    data.concat(payload_service.user_answers_map.values)
+    data.concat(payload_service.csv_row)
 
     data
   end

--- a/app/services/generate_csv_content.rb
+++ b/app/services/generate_csv_content.rb
@@ -23,7 +23,12 @@ class GenerateCsvContent
   end
 
   def csv_data
-    payload_service.user_answers_map.values
+    data = []
+
+    data << payload_service.submission_id
+    data.concat(payload_service.user_answers_map.values)
+
+    data
   end
 
   def csv_headers

--- a/app/services/generate_csv_content.rb
+++ b/app/services/generate_csv_content.rb
@@ -3,8 +3,8 @@ require 'tempfile'
 require_relative '../value_objects/attachment'
 
 class GenerateCsvContent
-  def initialize(payload:)
-    @payload = payload
+  def initialize(payload_service:)
+    @payload_service = payload_service
   end
 
   def execute
@@ -23,16 +23,12 @@ class GenerateCsvContent
   end
 
   def csv_data
-    data = []
-    data << payload[:submission][:serviceSlug]
-    data << payload[:submission][:submission_id]
-    data.concat(payload[:submission][:submissionAnswers].values)
-    data
+    payload_service.user_answers_map.values
   end
 
   def csv_headers
-    fixed_headers = ['slug', 'submission_id']
-    dynamic_headers = payload[:submission][:submissionAnswers].keys
+    fixed_headers = ['submission_id']
+    dynamic_headers = payload_service.user_answers_map.keys
 
     fixed_headers + dynamic_headers
   end
@@ -52,12 +48,12 @@ class GenerateCsvContent
 
   def generate_attachment_object(tmp_csv)
     attachment = Attachment.new(
-      filename: "#{payload[:submission][:submission_id]}-answers.csv",
+      filename: "#{payload_service.submission_id}-answers.csv",
       mimetype: 'text/csv'
     )
     attachment.file = tmp_csv
     attachment
   end
 
-  attr_reader :payload
+  attr_reader :payload_service
 end

--- a/app/services/submission_payload_service.rb
+++ b/app/services/submission_payload_service.rb
@@ -20,4 +20,17 @@ class SubmissionPayloadService
     end
     questions
   end
+
+  # return array representing as row in a csv
+  def csv_row
+    row = user_answers_map.values
+
+    row.map do |cell|
+      if cell.is_a?(Hash) || cell.is_a?(Array)
+        'data not available in csv format'
+      else
+        cell
+      end
+    end
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -134,7 +134,13 @@ FactoryBot.define do
               'questions' => [
                 {
                   'label' => 'Attach any documentation that supports your appeal',
-                  'answer' => 'an-image.jpg',
+                  'answer' => [{
+                    'fieldname' => 'upload[1]',
+                    'originalname' => 'hello_world.txt',
+                    'encoding' => '7bit',
+                    'mimetype' => 'text/plain'
+                  }],
+                  'human_value' => 'an-image.jpg',
                   'key' => 'documentation'
                 }
               ]

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -63,7 +63,8 @@ describe 'UserData API', type: :request do
               subject: 'Complain about a court or tribunal submission',
               email_body: 'this is the body of the email',
               include_attachments: true,
-              include_pdf: true
+              include_pdf: true,
+              include_csv: true
             }
           ]
         end
@@ -122,7 +123,7 @@ describe 'UserData API', type: :request do
 
           it 'sends 4 emails' do
             post_request
-            expect(stub_aws.api_requests.size).to eq(3)
+            expect(stub_aws.api_requests.size).to eq(4)
           end
 
           it 'email contains downloaded attachment' do
@@ -141,8 +142,15 @@ describe 'UserData API', type: :request do
           it 'sends the PDF of answers with the first email' do
             post_request
 
-            expect(raw_messages.first).to include('1/3')
+            expect(raw_messages.first).to include('1/4')
             expect(raw_messages.first).to include('-answers.pdf')
+          end
+
+          it 'sends the CSV of answers with the second email' do
+            post_request
+
+            expect(raw_messages.second).to include('2/4')
+            expect(raw_messages.second).to include('-answers.csv')
           end
 
           it 'creates a submission record' do

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -16,11 +16,13 @@ describe EmailOutputService do
       subject: 'Complain about a court or tribunal submission',
       email_body: 'Please find an application attached',
       include_pdf: include_pdf,
+      include_csv: include_csv,
       include_attachments: include_attachments
     }
   end
 
   let(:include_pdf) { false }
+  let(:include_csv) { false }
   let(:include_attachments) { false }
 
   let(:attachments) do
@@ -31,13 +33,29 @@ describe EmailOutputService do
   end
 
   let(:pdf_attachment) do
-    Attachment.new(type: 'output', url: nil, mimetype: 'application/pdf', filename: 'a generated pff', path: nil)
+    Attachment.new(type: 'output',
+                   url: nil,
+                   mimetype: 'application/pdf',
+                   filename: 'a generated pdf',
+                   path: nil)
+  end
+
+  let(:csv_attachment) do
+    Attachment.new(type: 'output',
+                   url: nil,
+                   mimetype: 'text/csv',
+                   filename: 'a generated csv',
+                   path: nil)
   end
 
   before do
     allow(email_service_mock).to receive(:send_mail)
 
-    service.execute(action: email_action, attachments: attachments, pdf_attachment: pdf_attachment, submission_id: 'an-id-2323')
+    subject.execute(action: email_action,
+                    attachments: attachments,
+                    pdf_attachment: pdf_attachment,
+                    csv_attachment: csv_attachment,
+                    submission_id: 'an-id-2323')
   end
 
   it 'execute sends an email' do

--- a/spec/services/generate_csv_content_spec.rb
+++ b/spec/services/generate_csv_content_spec.rb
@@ -1,21 +1,17 @@
+require 'rails_helper'
+
 require_relative '../../app/services/generate_csv_content'
+require_relative '../../app/services/submission_payload_service'
 
 describe GenerateCsvContent do
-  subject { described_class.new(payload: payload) }
+  subject { described_class.new(payload_service: payload_service) }
 
-  let(:payload) do
-    { submission: submission }
+  let(:payload_service) do
+    SubmissionPayloadService.new(payload)
   end
 
-  let(:submission) do
-    {
-      serviceSlug: 'fix-my-court',
-      submission_id: '11111111-1111-1111-1111-111111111111',
-      submissionAnswers: {
-        auto_name__1: "yes",
-        auto_name__2: "user@example.com",
-      }
-    }
+  let(:payload) do
+    create(:submission).decrypted_payload
   end
 
   context 'when requesting a csv with a submission' do
@@ -27,14 +23,40 @@ describe GenerateCsvContent do
     it 'assigns the correct info the the Attachment object' do
       result = subject.execute
 
-      expect(result.filename).to eq('11111111-1111-1111-1111-111111111111-answers.csv')
+      expect(result.filename).to eq("#{payload_service.submission_id}-answers.csv")
       expect(result.mimetype).to eq('text/csv')
 
       file_contents = File.open(result.path).read
       csv = CSV.new(file_contents).read
 
-      expect(csv[0]).to eql(['slug', 'submission_id', 'auto_name__1', 'auto_name__2'])
-      expect(csv[1]).to eql(['fix-my-court', '11111111-1111-1111-1111-111111111111', 'yes', 'user@example.com'])
+      expect(csv[0]).to eql([
+        "submission_id",
+        "usn",
+        "maat[1]",
+        "fullname",
+        "dob",
+        "solicitor_fullname",
+        "firm",
+        "solicitor_email",
+        "lapan",
+        "offence[1].type",
+        "offence[1].date",
+        "offence[1].reasons",
+        "documentation"
+      ])
+
+      expect(csv[1]).to eql(["1234567",
+                             "6123456",
+                             "john doe",
+                             "1 January 1990",
+                             "Mr Solicitor",
+                             "Pearson",
+                             "info@solicitor.co.uk",
+                             "1A234B",
+                             "Grand theft auto",
+                             "1 January 1990",
+                             "A genuine reason",
+                             "an-image.jpg"])
     end
   end
 end

--- a/spec/services/generate_csv_content_spec.rb
+++ b/spec/services/generate_csv_content_spec.rb
@@ -46,7 +46,8 @@ describe GenerateCsvContent do
         'documentation'
       ])
 
-      expect(csv[1]).to eql(['1234567',
+      expect(csv[1]).to eql([payload_service.submission_id,
+                             '1234567',
                              '6123456',
                              'john doe',
                              '1 January 1990',

--- a/spec/services/generate_csv_content_spec.rb
+++ b/spec/services/generate_csv_content_spec.rb
@@ -58,7 +58,7 @@ describe GenerateCsvContent do
                              'Grand theft auto',
                              '1 January 1990',
                              'A genuine reason',
-                             'an-image.jpg'])
+                             'data not available in csv format'])
     end
   end
   # rubocop:enable RSpec/ExampleLength

--- a/spec/services/generate_csv_content_spec.rb
+++ b/spec/services/generate_csv_content_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../../app/services/generate_csv_content'
+
+describe GenerateCsvContent do
+  subject { described_class.new(payload: payload) }
+
+  let(:payload) do
+    { submission: submission }
+  end
+
+  let(:submission) do
+    {
+      serviceSlug: 'fix-my-court',
+      submission_id: '11111111-1111-1111-1111-111111111111',
+      submissionAnswers: {
+        auto_name__1: "yes",
+        auto_name__2: "user@example.com",
+      }
+    }
+  end
+
+  context 'when requesting a csv with a submission' do
+    it 'returns an Attachment object' do
+      result = subject.execute
+      expect(result.class).to eq(Attachment)
+    end
+
+    it 'assigns the correct info the the Attachment object' do
+      result = subject.execute
+
+      expect(result.filename).to eq('11111111-1111-1111-1111-111111111111-answers.csv')
+      expect(result.mimetype).to eq('text/csv')
+
+      file_contents = File.open(result.path).read
+      csv = CSV.new(file_contents).read
+
+      expect(csv[0]).to eql(['slug', 'submission_id', 'auto_name__1', 'auto_name__2'])
+      expect(csv[1]).to eql(['fix-my-court', '11111111-1111-1111-1111-111111111111', 'yes', 'user@example.com'])
+    end
+  end
+end

--- a/spec/services/generate_csv_content_spec.rb
+++ b/spec/services/generate_csv_content_spec.rb
@@ -14,13 +14,14 @@ describe GenerateCsvContent do
     create(:submission).decrypted_payload
   end
 
+  # rubocop:disable RSpec/ExampleLength
   context 'when requesting a csv with a submission' do
     it 'returns an Attachment object' do
       result = subject.execute
       expect(result.class).to eq(Attachment)
     end
 
-    it 'assigns the correct info the the Attachment object' do
+    it 'assigns the correct info the Attachment object' do
       result = subject.execute
 
       expect(result.filename).to eq("#{payload_service.submission_id}-answers.csv")
@@ -30,33 +31,34 @@ describe GenerateCsvContent do
       csv = CSV.new(file_contents).read
 
       expect(csv[0]).to eql([
-        "submission_id",
-        "usn",
-        "maat[1]",
-        "fullname",
-        "dob",
-        "solicitor_fullname",
-        "firm",
-        "solicitor_email",
-        "lapan",
-        "offence[1].type",
-        "offence[1].date",
-        "offence[1].reasons",
-        "documentation"
+        'submission_id',
+        'usn',
+        'maat[1]',
+        'fullname',
+        'dob',
+        'solicitor_fullname',
+        'firm',
+        'solicitor_email',
+        'lapan',
+        'offence[1].type',
+        'offence[1].date',
+        'offence[1].reasons',
+        'documentation'
       ])
 
-      expect(csv[1]).to eql(["1234567",
-                             "6123456",
-                             "john doe",
-                             "1 January 1990",
-                             "Mr Solicitor",
-                             "Pearson",
-                             "info@solicitor.co.uk",
-                             "1A234B",
-                             "Grand theft auto",
-                             "1 January 1990",
-                             "A genuine reason",
-                             "an-image.jpg"])
+      expect(csv[1]).to eql(['1234567',
+                             '6123456',
+                             'john doe',
+                             '1 January 1990',
+                             'Mr Solicitor',
+                             'Pearson',
+                             'info@solicitor.co.uk',
+                             '1A234B',
+                             'Grand theft auto',
+                             '1 January 1990',
+                             'A genuine reason',
+                             'an-image.jpg'])
     end
   end
+  # rubocop:enable RSpec/ExampleLength
 end


### PR DESCRIPTION
- adds code to generate CSV from payload
- made some data not available in csv format namely file upload
- by default does not attach CSV to email to allow for backwards compatibility
- API: runner must send `include_csv` to `true` in `actions` to use this feature
- runner changes will come in a later pull request
- acceptance tests will fail on merge, a subsequent PR will be made to fix 