### PR TITLE
this adds iss to JWT payload

### DIFF
--- a/app/services/jwt_auth_service.rb
+++ b/app/services/jwt_auth_service.rb
@@ -6,7 +6,7 @@ class JwtAuthService
 
   def execute
     secret = service_token_cache.get(service_slug)
-    JWT.encode({}, secret, 'HS256', iss: service_slug)
+    JWT.encode({ iss: service_slug }, secret, 'HS256', iss: service_slug)
   end
 
   private


### PR DESCRIPTION
- according to the specification this should be present in the payload
  and not the headers
- it is included in both the header and payload for backwards
  compatability
- it will be removed from the headers in a future release