### PR TITLE
Only track metrics in live production

### DIFF
--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -1,5 +1,5 @@
 class Metrics
-  attr_reader :object, :client
+  attr_reader :object, :client, :logger
 
   def initialize(object, client = MixpanelClient.new, logger = Rails.logger)
     @object = object

--- a/app/services/mixpanel_client.rb
+++ b/app/services/mixpanel_client.rb
@@ -1,15 +1,20 @@
 require 'mixpanel-ruby'
 
 class MixpanelClient
-  attr_reader :metrics_access_key, :tracker
+  attr_accessor :metrics_access_key, :deployment_env, :tracker
   delegate :track, to: :tracker
+
+  MEASURED_ENVS = [
+    'live-production'
+  ].freeze
 
   def initialize
     @metrics_access_key = ENV['METRICS_ACCESS_KEY']
+    @deployment_env = ENV['FB_ENVIRONMENT_SLUG']
     @tracker = Mixpanel::Tracker.new(metrics_access_key)
   end
 
   def can_track?
-    @metrics_access_key.present?
+    metrics_access_key.present? && MEASURED_ENVS.include?(deployment_env)
   end
 end

--- a/spec/services/mixpanel_client_spec.rb
+++ b/spec/services/mixpanel_client_spec.rb
@@ -11,16 +11,36 @@ describe MixpanelClient do
 
   describe '#can_track?' do
     context 'when mixpanel access token is present' do
-      it 'returns true' do
-        allow(ENV).to receive(:[]).with('METRICS_ACCESS_KEY').and_return('foo')
-        expect(client).to be_can_track
+      context 'when env is production' do
+        it 'returns true' do
+          client.metrics_access_key = 'foo'
+          client.deployment_env = 'live-production'
+          expect(client).to be_can_track
+        end
+      end
+
+      context 'when env is not production' do
+        it 'returns false' do
+          client.metrics_access_key = 'foo'
+          client.deployment_env = 'live-dev'
+          expect(client).not_to be_can_track
+        end
       end
     end
 
     context 'when mixpanel access token is blank' do
-      it 'returns false' do
-        allow(ENV).to receive(:[]).with('METRICS_ACCESS_KEY').and_return(nil)
-        expect(client).not_to be_can_track
+      context 'when is nil' do
+        it 'returns false' do
+          client.metrics_access_key = nil
+          expect(client).not_to be_can_track
+        end
+      end
+
+      context 'when is blank' do
+        it 'returns false' do
+          client.metrics_access_key = ''
+          expect(client).not_to be_can_track
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

The secrets were not accepting blank values on env vars, so I added the code to just measure on live-production and made in such a way that if we need another environment we can add on the array.