### PR TITLE
Multiple attachments per submission email

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,9 +100,7 @@ workflows:
             - test
           filters:
             branches:
-              only:
-              - master
-              - multiple-attachments-per-submission-email
+              only: master
       - confirm_live_deploy:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,9 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only:
+              - master
+              - multiple-attachments-per-submission-email
       - confirm_live_deploy:
           type: approval
           requires:

--- a/app/services/attachment_generator.rb
+++ b/app/services/attachment_generator.rb
@@ -1,0 +1,45 @@
+class AttachmentGenerator
+  MAX_ATTACHMENTS_SIZE = 10_000_000 # 10MB in bytes. AWS SES limitation
+
+  attr_reader :sorted_attachments
+
+  def initialize
+    @sorted_attachments = []
+  end
+
+  def execute(action:, attachments:, pdf_attachment:)
+    email_attachments = []
+    email_attachments.concat(by_size(attachments)) if action.fetch(:include_attachments, false)
+    email_attachments.prepend(pdf_attachment) if action.fetch(:include_pdf, false)
+    attachments_per_email(email_attachments)
+  end
+
+  private
+
+  attr_writer :sorted_attachments
+
+  def by_size(attachments)
+    attachments.sort_by { |attachment| attachment.size }
+  end
+
+  def attachments_per_email(email_attachments)
+    per_email = []
+    email_attachments.each do |attachment|
+      if sum(per_email, attachment) >= MAX_ATTACHMENTS_SIZE
+        sorted_attachments << per_email
+        if attachment == email_attachments.last
+          sorted_attachments << [attachment]
+        else
+          per_email = [attachment]
+        end
+      else
+        per_email << attachment
+        sorted_attachments << per_email if attachment == email_attachments.last
+      end
+    end
+  end
+
+  def sum(per_email, to_add)
+    per_email.inject(0) { |sum, attachment| sum + attachment.size } + to_add.size
+  end
+end

--- a/app/services/email_output_service.rb
+++ b/app/services/email_output_service.rb
@@ -1,63 +1,31 @@
 class EmailOutputService
-  MAX_ATTACHMENTS_SIZE = 10_000_000 # 10MB in bytes. AWS SES limitation
-
-  def initialize(emailer:)
+  def initialize(emailer:, attachment_generator:)
     @emailer = emailer
+    @attachment_generator = attachment_generator
   end
 
   def execute(submission_id:, action:, attachments:, pdf_attachment:)
-    email_attachments = generate_attachments(action: action,
-                                             attachments: attachments,
-                                             pdf_attachment: pdf_attachment)
+    attachment_generator.execute(
+      action: action,
+      attachments: attachments,
+      pdf_attachment: pdf_attachment
+    )
 
-    if email_attachments.empty?
+    if attachment_generator.sorted_attachments.empty?
       send_single_email(
         action: action,
         subject: subject(subject: action.fetch(:subject), submission_id: submission_id)
       )
     else
-      send_emails_with_attachments(action, email_attachments, submission_id: submission_id)
+      send_emails_with_attachments(
+        action,
+        attachment_generator.sorted_attachments,
+        submission_id: submission_id
+      )
     end
   end
 
   private
-
-  def generate_attachments(action:, attachments:, pdf_attachment:)
-    email_attachments = []
-
-    if action.fetch(:include_attachments, false)
-      email_attachments = email_attachments.concat(by_size(attachments))
-    end
-    if action.fetch(:include_pdf, false)
-      email_attachments.prepend(pdf_attachment)
-    end
-
-    attachments_per_email(email_attachments)
-  end
-
-  def by_size(attachments)
-    attachments.sort_by { |attachment| attachment.size }
-  end
-
-  def sum(attachments, to_add)
-    attachments.inject(0) { |sum, attachment| sum + attachment.size } + to_add.size
-  end
-
-  def attachments_per_email(attachments)
-    all = []
-    per_email = []
-
-    attachments.each do |attachment|
-      if sum(per_email, attachment) >= MAX_ATTACHMENTS_SIZE
-        all << per_email
-        attachment == attachments.last ? all << [attachment] : per_email = [attachment]
-      else
-        per_email << attachment
-        all << per_email if attachment == attachments.last
-      end
-    end
-    all
-  end
 
   def send_emails_with_attachments(action, email_attachments, submission_id:)
     email_attachments.each_with_index do |attachments, index|
@@ -94,5 +62,5 @@ class EmailOutputService
     }
   end
 
-  attr_reader :emailer
+  attr_reader :emailer, :attachment_generator
 end

--- a/app/services/process_submission_service.rb
+++ b/app/services/process_submission_service.rb
@@ -23,12 +23,13 @@ class ProcessSubmissionService
       when 'email'
         pdf = generate_pdf(payload_service.payload, payload_service.submission_id)
 
-        attachments = generate_attachments(payload_service.attachments,
+        attachments = download_attachments(payload_service.attachments,
                                            submission.encrypted_user_id_and_token,
                                            submission.access_token)
 
         EmailOutputService.new(
-          emailer: EmailService
+          emailer: EmailService,
+          attachment_generator: AttachmentGenerator.new
         ).execute(submission_id: payload_service.submission_id,
                   action: action,
                   attachments: attachments,
@@ -37,7 +38,8 @@ class ProcessSubmissionService
         csv_attachment = generate_csv(payload_service)
 
         EmailOutputService.new(
-          emailer: EmailService
+          emailer: EmailService,
+          attachment_generator: AttachmentGenerator.new
         ).execute(submission_id: payload_service.submission_id,
                   action: action,
                   attachments: [csv_attachment],
@@ -56,7 +58,7 @@ class ProcessSubmissionService
 
   private
 
-  def generate_attachments(attachments_payload, token, access_token)
+  def download_attachments(attachments_payload, token, access_token)
     DownloadService.new(
       attachments: attachments_payload,
       target_dir: nil,

--- a/app/value_objects/attachment.rb
+++ b/app/value_objects/attachment.rb
@@ -21,4 +21,8 @@ class Attachment
 
     "#{raw_filename}.#{ext}"
   end
+
+  def size
+    File.size(path)
+  end
 end

--- a/spec/factories/attachment.rb
+++ b/spec/factories/attachment.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :attachment do
+    type { 'output' }
+    filename { SecureRandom.alphanumeric }
+    url { "example.com/#{filename}" }
+    mimetype { 'image/jpeg' }
+    path {}
+
+    initialize_with { new(filename: filename, mimetype: mimetype) }
+  end
+end

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -120,9 +120,10 @@ describe 'UserData API', type: :request do
             expect(WebMock).to have_requested(:get, %r{fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/ioj/user/a239313d-4d2d-4a16-b5ef-69d6e8e53e86/}).times(2)
           end
 
-          it 'sends 3 emails' do
+          # the tmp file sizes are small so there will only ever be a single email
+          it 'sends the correct number of emails' do
             post_request
-            expect(stub_aws.api_requests.size).to eq(3)
+            expect(stub_aws.api_requests.size).to eq(1)
           end
 
           it 'email contains downloaded attachment' do
@@ -138,10 +139,10 @@ describe 'UserData API', type: :request do
             expect(raw_messages).to all(include('this is the body of the email'))
           end
 
-          it 'sends the PDF of answers with the first email' do
+          it 'sends the PDF of answers in the same email' do
             post_request
 
-            expect(raw_messages.first).to include('1/3')
+            expect(raw_messages.first).to include('1/1')
             expect(raw_messages.first).to include('-answers.pdf')
           end
 

--- a/spec/services/attachment_generator_spec.rb
+++ b/spec/services/attachment_generator_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+require_relative '../../app/services/attachment_generator'
+
+describe AttachmentGenerator do
+  subject(:generator) { described_class.new }
+
+  let(:upload1) { build(:attachment) }
+  let(:upload2) { build(:attachment) }
+  let(:upload3) { build(:attachment) }
+  let(:upload4) { build(:attachment) }
+  let(:upload5) { build(:attachment) }
+  let(:upload6) { build(:attachment) }
+  let(:pdf_attachment) { build(:attachment, mimetype: 'application/pdf', url: nil) }
+
+  before do
+    allow(upload1).to receive(:size).and_return(5678)
+    allow(upload2).to receive(:size).and_return(1234)
+    allow(upload3).to receive(:size).and_return(9_999_999)
+    allow(upload4).to receive(:size).and_return(44_444)
+    allow(upload5).to receive(:size).and_return(111)
+    allow(upload6).to receive(:size).and_return(9_999_999)
+    allow(pdf_attachment).to receive(:size).and_return(7777)
+  end
+
+  # rubocop:disable RSpec/ExampleLength
+  context 'when no attachments or pdfs are required' do
+    it 'will not sort any attachments' do
+      subject.execute(action: {}, attachments: [upload1, upload2], pdf_attachment: pdf_attachment)
+      expect(subject.sorted_attachments).to be_empty
+    end
+  end
+
+  context 'when included attachments are required' do
+    it 'sorts the files by size, smallest first' do
+      subject.execute(
+        action: { include_attachments: true },
+        attachments: [upload1, upload2],
+        pdf_attachment: nil
+      )
+
+      expect(subject.sorted_attachments).to eq([[upload2, upload1]])
+    end
+
+    it 'splits files into separate email payloads when above the maximum limit' do
+      subject.execute(
+        action: { include_attachments: true },
+        attachments: [upload1, upload3],
+        pdf_attachment: nil
+      )
+
+      expect(subject.sorted_attachments).to eq(
+        [
+          [upload1],
+          [upload3]
+        ]
+      )
+    end
+  end
+
+  context 'when pdf attachment is required' do
+    it 'will sort only the pdf attachment' do
+      allow(pdf_attachment).to receive(:size).and_return(7777)
+      subject.execute(
+        action: { include_pdf: true },
+        attachments: nil,
+        pdf_attachment: pdf_attachment
+      )
+
+      expect(subject.sorted_attachments).to eq([[pdf_attachment]])
+    end
+  end
+
+  context 'when both attachments and pdf submission are required' do
+    it 'puts pdf submission first and remaining attachments by size' do
+      subject.execute(
+        action: { include_attachments: true, include_pdf: true },
+        attachments: [upload1, upload2],
+        pdf_attachment: pdf_attachment
+      )
+
+      expect(subject.sorted_attachments).to eq([[pdf_attachment, upload2, upload1]])
+    end
+
+    it 'will split all files over multiple email payloads when the maximum limit is reached' do
+      subject.execute(
+        action: { include_attachments: true, include_pdf: true },
+        attachments: [upload1, upload2, upload3, upload4, upload5, upload6],
+        pdf_attachment: pdf_attachment
+      )
+
+      expect(subject.sorted_attachments).to eq(
+        [
+          [pdf_attachment, upload5, upload2, upload1, upload4],
+          [upload3],
+          [upload6]
+        ]
+      )
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
+end

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -23,47 +23,15 @@ describe EmailOutputService do
   let(:include_pdf) { false }
   let(:include_attachments) { false }
 
-  let(:upload1) do
-    Attachment.new(
-      type: 'output',
-      url: 'example.com/upload1',
-      mimetype: 'application/pdf',
-      filename: 'upload1',
-      path: nil
-    )
-  end
-  let(:upload2) do
-    Attachment.new(
-      type: 'output',
-      url: 'example.com/upload2',
-      mimetype: 'application/json',
-      filename: 'upload2',
-      path: nil
-    )
-  end
-  let(:upload3) do
-    Attachment.new(
-      type: 'output',
-      url: 'example.com/upload3',
-      mimetype: 'image/jpeg',
-      filename: 'upload3',
-      path: nil
-    )
-  end
+  let(:upload1) { build(:attachment) }
+  let(:upload2) { build(:attachment) }
+  let(:upload3) { build(:attachment) }
 
   let(:attachments) do
     [upload1, upload2, upload3]
   end
 
-  let(:pdf_attachment) do
-    Attachment.new(
-      type: 'output',
-      url: nil,
-      mimetype: 'application/pdf',
-      filename: 'a generated pdf',
-      path: nil
-    )
-  end
+  let(:pdf_attachment) { build(:attachment, mimetype: 'application/pdf', url: nil) }
 
   before do
     allow(upload1).to receive(:size).and_return(1234)

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -1,11 +1,18 @@
 require_relative '../../app/services/email_output_service'
 require_relative '../../app/services/email_service'
+require_relative '../../app/services/attachment_generator'
 require_relative '../../app/value_objects/attachment'
 
 describe EmailOutputService do
-  subject(:service) { described_class.new(emailer: email_service_mock) }
+  subject(:service) do
+    described_class.new(
+      emailer: email_service_mock,
+      attachment_generator: attachment_generator
+    )
+  end
 
   let(:email_service_mock) { class_double(EmailService) }
+  let(:attachment_generator) { AttachmentGenerator.new }
 
   let(:email_action) do
     {

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -121,8 +121,8 @@ describe EmailOutputService do
     let(:include_attachments) { true }
     let(:include_pdf) { true }
 
-    it 'groups attachments for all emails based on attachment size' do
-      first_email_attachments = [upload1, upload2, pdf_attachment]
+    it 'groups attachments per email, pdf submission first remainder based on attachment size, ' do
+      first_email_attachments = [pdf_attachment, upload1, upload2]
       second_email_attachments = [upload3]
 
       expect(email_service_mock).to have_received(:send_mail).exactly(2).times

--- a/spec/services/webhook_attachment_service_spec.rb
+++ b/spec/services/webhook_attachment_service_spec.rb
@@ -14,8 +14,8 @@ describe WebhookAttachmentService do
 
   let(:attachments) do
     [
-      Attachment.new(type: 'output', url: attachment_1, mimetype: 'application/pdf', filename: 'form1', path: nil),
-      Attachment.new(type: 'output', url: attachment_2, mimetype: 'application/json', filename: 'afile', path: nil)
+      build(:attachment, url: attachment_1, mimetype: 'application/pdf', filename: 'form1'),
+      build(:attachment, url: attachment_2, mimetype: 'application/json', filename: 'afile')
     ]
   end
 

--- a/spec/value_objects/raw_message_spec.rb
+++ b/spec/value_objects/raw_message_spec.rb
@@ -18,10 +18,9 @@ RSpec.describe RawMessage do
   end
 
   let(:attachment) do
-    Attachment.new(
-      type: nil,
+    build(
+      :attachment,
       filename: 'some-file-name.jpg',
-      url: nil,
       mimetype: 'application/pdf',
       path: file_fixture('hello_world.txt')
     )
@@ -67,10 +66,9 @@ RSpec.describe RawMessage do
 
   context 'when filename does not have extension' do
     let(:attachment) do
-      Attachment.new(
-        type: nil,
+      build(
+        :attachment,
         filename: 'some-file-name',
-        url: nil,
         mimetype: 'application/pdf',
         path: file_fixture('hello_world.txt')
       )


### PR DESCRIPTION
- Add file size method to attachments
  This will allow for `size` to be called on all attachments, including pdf's and csv's as they use the Attachment class internally.

- Attach multiple files to submission emails
  As per [this ADR](https://github.com/ministryofjustice/form-builder/blob/master/decisions/0006-reduce-number-of-emails-per-submission.md) we want to reduce the number of emails that is sent with each form submission.

- Ensure PDF answers file is the first attachment
  Before grouping attachments up to the maximum allowed per email, the pdf
answers file was always the first email to be sent. It is not quite the same thing, but here we make sure that this answers pdf is the first attachment in the email. This is on the assumption that AWS SES keeps the same order of attachments that it receives.

- Use factory for attachment class in specs

- Move attachment sorting into its own class
  The logic is probably complicated enough that it could do with living in its own class which also enables us to test it easier.

https://trello.com/c/ZWUVubLI/427-reduce-number-of-email-with-multiple-upload-forms