### PR TITLE
Adjust maximum email size limit for submissions

### DIFF
--- a/app/services/attachment_generator.rb
+++ b/app/services/attachment_generator.rb
@@ -1,5 +1,8 @@
 class AttachmentGenerator
-  MAX_ATTACHMENTS_SIZE = 10_000_000 # 10MB in bytes. AWS SES limitation
+  # AWS SES limit is 10MB for each email message including all attachments and images
+  # https://aws.amazon.com/ses/faqs/#Limits_and_Restrictions
+  # Leaving a 1MB headroom for email contents, which is pretty generous
+  MAX_EMAIL_SIZE = 9_000_000
 
   attr_reader :sorted_attachments
 
@@ -25,7 +28,7 @@ class AttachmentGenerator
   def attachments_per_email(email_attachments)
     per_email = []
     email_attachments.each do |attachment|
-      if sum(per_email, attachment) >= MAX_ATTACHMENTS_SIZE
+      if sum(per_email, attachment) >= MAX_EMAIL_SIZE
         sorted_attachments << per_email
         if attachment == email_attachments.last
           sorted_attachments << [attachment]

--- a/spec/services/attachment_generator_spec.rb
+++ b/spec/services/attachment_generator_spec.rb
@@ -15,10 +15,10 @@ describe AttachmentGenerator do
   before do
     allow(upload1).to receive(:size).and_return(5678)
     allow(upload2).to receive(:size).and_return(1234)
-    allow(upload3).to receive(:size).and_return(9_999_999)
+    allow(upload3).to receive(:size).and_return(8_999_999)
     allow(upload4).to receive(:size).and_return(44_444)
     allow(upload5).to receive(:size).and_return(111)
-    allow(upload6).to receive(:size).and_return(9_999_999)
+    allow(upload6).to receive(:size).and_return(8_999_999)
     allow(pdf_attachment).to receive(:size).and_return(7777)
   end
 

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -43,7 +43,7 @@ describe EmailOutputService do
   before do
     allow(upload1).to receive(:size).and_return(1234)
     allow(upload2).to receive(:size).and_return(5678)
-    allow(upload3).to receive(:size).and_return(9_999_999)
+    allow(upload3).to receive(:size).and_return(8_999_999)
     allow(pdf_attachment).to receive(:size).and_return(7777)
 
     allow(email_service_mock).to receive(:send_mail)


### PR DESCRIPTION
The [AWS SES docs](https://aws.amazon.com/ses/faqs/#Limits_and_Restrictions)
state that the maximum limit of 10MB also includes the contents of the
email, not just the attachments.

We are leaving 1MB headroom for email contents, which is very generous
as we do not currently use any images etc.

https://trello.com/c/ZWUVubLI/427-reduce-number-of-email-with-multiple-upload-forms