### PR TITLE
Reduce the max attachment size to 7MB

### DIFF
--- a/app/services/attachment_generator.rb
+++ b/app/services/attachment_generator.rb
@@ -44,6 +44,6 @@ class AttachmentGenerator
   end
 
   def sum(per_email, to_add)
-    per_email.inject(0) { |sum, attachment| sum + attachment.size } + to_add.size
+    per_email.map(&:size).sum + to_add.size
   end
 end

--- a/app/services/attachment_generator.rb
+++ b/app/services/attachment_generator.rb
@@ -1,8 +1,9 @@
 class AttachmentGenerator
   # AWS SES limit is 10MB for each email message including all attachments and images
   # https://aws.amazon.com/ses/faqs/#Limits_and_Restrictions
-  # Leaving a 1MB headroom for email contents, which is pretty generous
-  MAX_EMAIL_SIZE = 9_000_000
+  # Leaving a 3MB headroom for email body contents and the fact that the attachments
+  # get base64 encoded before being sent
+  MAX_EMAIL_SIZE = 7_000_000
 
   attr_reader :sorted_attachments
 

--- a/app/value_objects/raw_message.rb
+++ b/app/value_objects/raw_message.rb
@@ -11,6 +11,12 @@ class RawMessage
   end
 
   def to_s
+    inline_attachments = @attachments.map do |attachment|
+      inline_attachment(attachment)
+    end
+
+    Rails.logger.info("Attachments size: #{inline_attachments.join.bytesize}")
+
     <<~RAW_MESSAGE
       From: #{@from}
       To: #{@to}
@@ -28,7 +34,7 @@ class RawMessage
       #{[@body_parts[:'text/plain']].pack('M')}
 
       --NextPart
-      #{@attachments.map { |attachment| inline_attachment(attachment) }.join("\n\n--NextPart\n")}
+      #{inline_attachments.join("\n\n--NextPart\n")}
 
     RAW_MESSAGE
   end


### PR DESCRIPTION
- The attachments are base64 encoded before being sent to AWS SES. This adds a little bit to the size of the data and when coupled with the email body contents etc it gets too close to the 10MB limit per email

- Also add some more logging around the attachments size after they have been base64 encoded

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>