### PR TITLE
Do not retry email submissions that previously succeeded

### DIFF
--- a/app/models/email_payload.rb
+++ b/app/models/email_payload.rb
@@ -1,0 +1,3 @@
+class EmailPayload < ActiveRecord::Base
+  serialize :attachments, Array
+end

--- a/app/models/email_payload.rb
+++ b/app/models/email_payload.rb
@@ -1,3 +1,5 @@
 class EmailPayload < ActiveRecord::Base
-  serialize :attachments, Array
+  def decrypted_attachments
+    EncryptionService.new.decrypt(attachments)
+  end
 end

--- a/app/services/db_sweeper.rb
+++ b/app/services/db_sweeper.rb
@@ -1,11 +1,26 @@
 class DbSweeper
   def call
-    Submission.where('created_at < ?', age_threshold).destroy_all
+    vanquish_submissions
+    annihilate_email_payloads
   end
 
   private
 
-  def age_threshold
+  def vanquish_submissions
+    Submission.where('created_at < ?', submission_age_threshold).destroy_all
+  end
+
+  def annihilate_email_payloads
+    EmailPayload.where('created_at < ?', email_payload_age_threshold)
+                .where.not(succeeded_at: nil)
+                .destroy_all
+  end
+
+  def submission_age_threshold
     28.days.ago
+  end
+
+  def email_payload_age_threshold
+    7.days.ago
   end
 end

--- a/app/services/process_submission_service.rb
+++ b/app/services/process_submission_service.rb
@@ -29,7 +29,8 @@ class ProcessSubmissionService
 
         EmailOutputService.new(
           emailer: EmailService,
-          attachment_generator: AttachmentGenerator.new
+          attachment_generator: AttachmentGenerator.new,
+          encryption_service: EncryptionService.new
         ).execute(submission_id: payload_service.submission_id,
                   action: action,
                   attachments: attachments,
@@ -39,7 +40,8 @@ class ProcessSubmissionService
 
         EmailOutputService.new(
           emailer: EmailService,
-          attachment_generator: AttachmentGenerator.new
+          attachment_generator: AttachmentGenerator.new,
+          encryption_service: EncryptionService.new
         ).execute(submission_id: payload_service.submission_id,
                   action: action,
                   attachments: [csv_attachment],

--- a/db/migrate/20200506161639_create_email_payloads.rb
+++ b/db/migrate/20200506161639_create_email_payloads.rb
@@ -1,0 +1,10 @@
+class CreateEmailPayloads < ActiveRecord::Migration[6.0]
+  def change
+    create_table :email_payloads, id: :uuid do |t|
+      t.string   :submission_id
+      t.string   :attachments
+      t.datetime :succeeded_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_09_105320) do
+ActiveRecord::Schema.define(version: 2020_05_06_161639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -28,6 +28,14 @@ ActiveRecord::Schema.define(version: 2020_01_09_105320) do
     t.string "queue"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "email_payloads", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "submission_id"
+    t.string "attachments"
+    t.datetime "succeeded_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/email_payload.rb
+++ b/spec/factories/email_payload.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :email_payload do
+    submission_id { SecureRandom.uuid }
+    attachments { [] }
+    succeeded_at {}
+  end
+end

--- a/spec/models/email_payload_spec.rb
+++ b/spec/models/email_payload_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe EmailPayload do
+  describe 'decrypted_payload' do
+    let(:attachments) { ['call', 'me', 'ishmael'] }
+    let(:encrypted_attachments) { EncryptionService.new.encrypt(attachments) }
+
+    let(:email_payload) { described_class.create!(attachments: encrypted_attachments) }
+
+    it 'decrypts the attachments' do
+      expect(email_payload.decrypted_attachments).to eq(attachments)
+    end
+  end
+end

--- a/spec/models/email_payload_spec.rb
+++ b/spec/models/email_payload_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe EmailPayload do
   describe 'decrypted_payload' do
-    let(:attachments) { ['call', 'me', 'ishmael'] }
+    let(:attachments) { %w[call me ishmael] }
     let(:encrypted_attachments) { EncryptionService.new.encrypt(attachments) }
 
     let(:email_payload) { described_class.create!(attachments: encrypted_attachments) }

--- a/spec/services/db_sweeper_spec.rb
+++ b/spec/services/db_sweeper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DbSweeper do
         create(:submission, created_at: 5.days.ago)
       end
 
-      it 'destroys the older records' do
+      it 'destroys the older submission records' do
         expect do
           subject.call
         end.to change(Submission, :count).by(-1)
@@ -20,10 +20,36 @@ RSpec.describe DbSweeper do
         create(:submission, created_at: 5.days.ago)
       end
 
-      it 'leaves records intact' do
+      it 'leaves submission records intact' do
         expect do
           subject.call
         end.not_to change(Submission, :count)
+      end
+    end
+
+    context 'when there are email payloads over 7 days old' do
+      before do
+        create(:email_payload, created_at: 10.days.ago)
+        create(:email_payload, created_at: 10.days.ago, succeeded_at: 10.days.ago)
+        create(:email_payload, created_at: 5.days.ago, succeeded_at: 5.days.ago)
+      end
+
+      it 'destroys the older records unless email sending failed' do
+        expect do
+          subject.call
+        end.to change(EmailPayload, :count).by(-1)
+      end
+    end
+
+    context 'when there are no email payloads over 7 days old' do
+      before do
+        create(:email_payload, created_at: 5.days.ago)
+      end
+
+      it 'leaves email payload records intact' do
+        expect do
+          subject.call
+        end.not_to change(EmailPayload, :count)
       end
     end
   end

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 require_relative '../../app/services/email_output_service'
 require_relative '../../app/services/email_service'
 require_relative '../../app/services/attachment_generator'
@@ -7,12 +8,14 @@ describe EmailOutputService do
   subject(:service) do
     described_class.new(
       emailer: email_service_mock,
-      attachment_generator: attachment_generator
+      attachment_generator: attachment_generator,
+      encryption_service: encryption_service
     )
   end
 
   let(:email_service_mock) { class_double(EmailService) }
   let(:attachment_generator) { AttachmentGenerator.new }
+  let(:encryption_service) { EncryptionService.new }
 
   let(:email_action) do
     {
@@ -40,69 +43,159 @@ describe EmailOutputService do
 
   let(:pdf_attachment) { build(:attachment, mimetype: 'application/pdf', url: nil) }
 
+  let(:execution_payload) do
+    {
+      action: email_action,
+      attachments: attachments,
+      pdf_attachment: pdf_attachment,
+      submission_id: 'an-id-2323'
+    }
+  end
+  let(:send_email_payload) do
+    {
+      to: 'bob.admin@digital.justice.gov.uk',
+      from: 'form-builder@digital.justice.gov.uk',
+      subject: 'Complain about a court or tribunal submission {an-id-2323} [1/1]',
+      body_parts: { 'text/plain': 'Please find an application attached' },
+      attachments: []
+    }
+  end
+
   before do
     allow(upload1).to receive(:size).and_return(1234)
     allow(upload2).to receive(:size).and_return(5678)
     allow(upload3).to receive(:size).and_return(8_999_999)
     allow(pdf_attachment).to receive(:size).and_return(7777)
-
-    allow(email_service_mock).to receive(:send_mail)
-    subject.execute(action: email_action,
-                    attachments: attachments,
-                    pdf_attachment: pdf_attachment,
-                    submission_id: 'an-id-2323')
   end
 
-  it 'execute sends an email' do
-    expect(email_service_mock).to have_received(:send_mail).with(to: 'bob.admin@digital.justice.gov.uk',
-                                                                 from: 'form-builder@digital.justice.gov.uk',
-                                                                 subject: 'Complain about a court or tribunal submission {an-id-2323} [1/1]',
-                                                                 body_parts: { 'text/plain': 'Please find an application attached' },
-                                                                 attachments: []).once
+  context 'when email sending succeeds' do
+    before do
+      allow(email_service_mock).to receive(:send_mail)
+      subject.execute(execution_payload)
+    end
+
+    it 'execute sends an email' do
+      expect(email_service_mock).to have_received(:send_mail).with(send_email_payload).once
+    end
+
+    context 'when a user uploaded attachments are required but not answers pdf' do
+      let(:include_attachments) { true }
+      let(:first_email_attachments) { [upload1, upload2] }
+      let(:second_email_attachments) { [upload3] }
+
+      it 'groups attachments into emails up to maximum limit' do
+        expect(email_service_mock).to have_received(:send_mail).exactly(2).times
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: first_email_attachments)).once
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: second_email_attachments)).once
+      end
+
+      it 'the subject is numbered by how many separate emails there are' do
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]')).once
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]')).once
+      end
+
+      it 'creates the required email payload records' do
+        email_payloads = EmailPayload.all
+
+        expect(email_payloads.count).to eq(2)
+        email_payloads.each { |payload| expect(payload.succeeded_at).not_to be_nil }
+        expect(email_payloads.first.decrypted_attachments).to eq(first_email_attachments.map(&:filename).sort)
+        expect(email_payloads.last.decrypted_attachments).to eq(second_email_attachments.map(&:filename).sort)
+      end
+    end
+
+    context 'when a user answers pdf is needed but not uploaded attachments' do
+      let(:include_pdf) { true }
+
+      it 'sends an email with the generated pdf as a attachment' do
+        expect(email_service_mock).to have_received(:send_mail).exactly(1).times
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: [pdf_attachment])).once
+      end
+
+      it 'the subject is numbered [1/1] as there will be a single email' do
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [1/1]')).once
+      end
+    end
+
+    context 'when both uploaded attachments and answers pdf are required' do
+      let(:include_attachments) { true }
+      let(:include_pdf) { true }
+
+      it 'groups attachments per email, pdf submission first remainder based on attachment size, ' do
+        first_email_attachments = [pdf_attachment, upload1, upload2]
+        second_email_attachments = [upload3]
+
+        expect(email_service_mock).to have_received(:send_mail).exactly(2).times
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: first_email_attachments)).once
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: second_email_attachments)).once
+      end
+    end
   end
 
-  context 'when a user uploaded attachments are required but not answers pdf' do
+  # rubocop:disable RSpec/ExampleLength
+  context 'when email sending fails' do
     let(:include_attachments) { true }
-
-    it 'groups attachments into emails up to maximum limit' do
-      first_email_attachments = [upload1, upload2]
-      second_email_attachments = [upload3]
-
-      expect(email_service_mock).to have_received(:send_mail).exactly(2).times
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: first_email_attachments)).once
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: second_email_attachments)).once
+    let(:first_email_attachments) { [upload1, upload2] }
+    let(:second_email_attachments) { [upload3] }
+    let(:first_payload) do
+      send_email_payload.merge(
+        subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]',
+        attachments: first_email_attachments
+      )
+    end
+    let(:second_payload) do
+      send_email_payload.merge(
+        subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]',
+        attachments: second_email_attachments
+      )
     end
 
-    it 'the subject is numbered by how many separate emails there are' do
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]')).once
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]')).once
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'only retries emails that did not previously succeed' do
+      allow(email_service_mock).to receive(:send_mail).with(first_payload)
+      allow(email_service_mock).to receive(:send_mail).with(second_payload).and_raise(Aws::SES::Errors::MessageRejected.new({}, 'it was the day my grandmother exploded'))
+
+      expect { subject.execute(execution_payload) }.to raise_error(Aws::SES::Errors::MessageRejected)
+
+      email_payloads = EmailPayload.all
+      expect(email_payloads.count).to eq(2)
+      email_payloads.each do |payload|
+        if payload.decrypted_attachments == second_email_attachments.map(&:filename).sort
+          expect(payload.succeeded_at).to be_nil
+        end
+      end
+
+      allow(email_service_mock).to receive(:send_mail)
+      expect(email_service_mock).not_to receive(:send_mail).with(first_payload) # rubocop:disable  RSpec/MessageSpies
+
+      subject.execute(execution_payload)
+
+      email_payloads = EmailPayload.all
+      expect(email_payloads.count).to eq(2)
+      email_payloads.each do |payload|
+        if payload.decrypted_attachments == second_email_attachments.map(&:filename).sort
+          expect(payload.succeeded_at).not_to be_nil
+        end
+      end
     end
+
+    it 'does not care about the ordering of the attachments when retrying' do
+      allow(email_service_mock).to receive(:send_mail).with(first_payload).and_raise(Aws::SES::Errors::MessageRejected.new({}, 'all children, except one, grow up'))
+      allow(email_service_mock).to receive(:send_mail).with(second_payload)
+      expect { subject.execute(execution_payload) }.to raise_error(Aws::SES::Errors::MessageRejected)
+
+      allow(email_service_mock).to receive(:send_mail)
+      subject.execute(execution_payload.merge(attachments: [upload3, upload2, upload1]))
+
+      email_payloads = EmailPayload.all
+      expect(email_payloads.count).to eq(2)
+      email_payloads.each do |payload|
+        if payload.decrypted_attachments == second_email_attachments.map(&:filename).sort
+          expect(payload.succeeded_at).not_to be_nil
+        end
+      end
+    end
+    # rubocop:enable RSpec/MultipleExpectations
   end
-
-  context 'when a user answers pdf is needed but not uploaded attachments' do
-    let(:include_pdf) { true }
-
-    it 'sends an email with the generated pdf as a attachment' do
-      expect(email_service_mock).to have_received(:send_mail).exactly(1).times
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: [pdf_attachment])).once
-    end
-
-    it 'the subject is numbered [1/1] as there will be a single email' do
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [1/1]')).once
-    end
-  end
-
-  context 'when both uploaded attachments and answers pdf are required' do
-    let(:include_attachments) { true }
-    let(:include_pdf) { true }
-
-    it 'groups attachments per email, pdf submission first remainder based on attachment size, ' do
-      first_email_attachments = [pdf_attachment, upload1, upload2]
-      second_email_attachments = [upload3]
-
-      expect(email_service_mock).to have_received(:send_mail).exactly(2).times
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: first_email_attachments)).once
-      expect(email_service_mock).to have_received(:send_mail).with(hash_including(attachments: second_email_attachments)).once
-    end
-  end
+  # rubocop:enable RSpec/ExampleLength
 end


### PR DESCRIPTION
## Add emails payload table

We need to  hold a little bit of state about the attachments that are sent in the emails for each submission.

## Do not retry email submissions that previously succeeded

Previously when an email failed to send in a Delayed::Job it would retry ALL emails, including those which previously succeeded, up to the maximum current retry limit.

Now we write each emails payload to the DB and whether or not the email was sent successfully. Unsuccessful emails will continue to be retried but those which previously succeeded will be ignored.

## Clean up old email payload records …

We don't really need to keep email payload records unless they failed. 28 days is a bit excessive so clean them up every 7 days.

https://trello.com/c/248f4veP/476-stop-looping-submission-emails-that-have-been-successfully-sent