### PR TITLE
Store recipient specific email payloads

### DIFF
--- a/app/models/email_payload.rb
+++ b/app/models/email_payload.rb
@@ -2,4 +2,8 @@ class EmailPayload < ActiveRecord::Base
   def decrypted_attachments
     EncryptionService.new.decrypt(attachments)
   end
+
+  def decrypted_to
+    EncryptionService.new.decrypt(to)
+  end
 end

--- a/db/migrate/20200511104115_add_to_column_to_email_payload.rb
+++ b/db/migrate/20200511104115_add_to_column_to_email_payload.rb
@@ -1,0 +1,5 @@
+class AddToColumnToEmailPayload < ActiveRecord::Migration[6.0]
+  def change
+    add_column :email_payloads, :to, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_06_161639) do
+ActiveRecord::Schema.define(version: 2020_05_11_104115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2020_05_06_161639) do
     t.datetime "succeeded_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "to"
   end
 
   create_table "submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/email_payload_spec.rb
+++ b/spec/models/email_payload_spec.rb
@@ -3,12 +3,23 @@ require 'rails_helper'
 RSpec.describe EmailPayload do
   describe 'decrypted_payload' do
     let(:attachments) { %w[call me ishmael] }
+    let(:to) { 'ahab@pequod.boat' }
+    let(:encrypted_to) { EncryptionService.new.encrypt(to) }
     let(:encrypted_attachments) { EncryptionService.new.encrypt(attachments) }
 
-    let(:email_payload) { described_class.create!(attachments: encrypted_attachments) }
+    let(:email_payload) do
+      described_class.create!(
+        to: encrypted_to,
+        attachments: encrypted_attachments
+      )
+    end
 
     it 'decrypts the attachments' do
       expect(email_payload.decrypted_attachments).to eq(attachments)
+    end
+
+    it 'decrypts the to' do
+      expect(email_payload.decrypted_to).to eq(to)
     end
   end
 end


### PR DESCRIPTION
## Add 'to' column to EmailPayload table

A submission ID and file attachment names are not specific enough for email payloads. Those same attachments can be sent to multiple recipients.

## Save encrypted 'to' in each EmailPayload

The 'to' field enables the EmailPayload record to be unique across email recipients.

Testing edge cases for this is a little tricky :(

https://trello.com/c/248f4veP/476-stop-looping-submission-emails-that-have-been-successfully-sent