### PR TITLE
Differentiate between submission ID and payload submission ID

### DIFF
--- a/app/services/json_webhook_service.rb
+++ b/app/services/json_webhook_service.rb
@@ -4,11 +4,11 @@ class JsonWebhookService
     @webhook_destination_adapter = webhook_destination_adapter
   end
 
-  def execute(user_answers:, service_slug:, submission_id:)
+  def execute(user_answers:, service_slug:, payload_submission_id:)
     webhook_destination_adapter.send_webhook(
       body: {
         "serviceSlug": service_slug,
-        "submissionId": submission_id,
+        "submissionId": payload_submission_id,
         "submissionAnswers": user_answers,
         "attachments": webhook_attachment_fetcher.execute
       }.to_json

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -18,9 +18,14 @@ describe EmailOutputService do
     described_class.new(
       emailer: email_service_mock,
       attachment_generator: attachment_generator,
-      encryption_service: encryption_service
+      encryption_service: encryption_service,
+      submission_id: submission_id,
+      payload_submission_id: payload_submission_id
     )
   end
+
+  let(:submission_id) { SecureRandom.uuid }
+  let(:payload_submission_id) { 'an-id-2323' }
 
   let(:email_service_mock) { class_double(EmailService) }
   let(:attachment_generator) { AttachmentGenerator.new }
@@ -56,8 +61,7 @@ describe EmailOutputService do
     {
       action: email_action,
       attachments: attachments,
-      pdf_attachment: pdf_attachment,
-      submission_id: 'an-id-2323'
+      pdf_attachment: pdf_attachment
     }
   end
   let(:send_email_payload) do
@@ -212,14 +216,18 @@ describe EmailOutputService do
       described_class.new(
         emailer: email_service_mock,
         attachment_generator: AttachmentGenerator.new,
-        encryption_service: encryption_service
+        encryption_service: encryption_service,
+        submission_id: submission_id,
+        payload_submission_id: payload_submission_id
       )
     end
     let(:second_service) do
       described_class.new(
         emailer: email_service_mock,
         attachment_generator: AttachmentGenerator.new,
-        encryption_service: encryption_service
+        encryption_service: encryption_service,
+        submission_id: submission_id,
+        payload_submission_id: payload_submission_id
       )
     end
     let(:first_email_attachments) { [pdf_attachment, upload1, upload2] }
@@ -261,14 +269,18 @@ describe EmailOutputService do
         described_class.new(
           emailer: email_service_mock,
           attachment_generator: AttachmentGenerator.new,
-          encryption_service: encryption_service
+          encryption_service: encryption_service,
+          submission_id: submission_id,
+          payload_submission_id: payload_submission_id
         )
       end
       let(:fourth_service) do
         described_class.new(
           emailer: email_service_mock,
           attachment_generator: AttachmentGenerator.new,
-          encryption_service: encryption_service
+          encryption_service: encryption_service,
+          submission_id: submission_id,
+          payload_submission_id: payload_submission_id
         )
       end
       let(:first_payload) do

--- a/spec/services/json_webhook_service_spec.rb
+++ b/spec/services/json_webhook_service_spec.rb
@@ -49,7 +49,7 @@ describe JsonWebhookService do
     allow(webhook_destination_adapter).to receive(:send_webhook)
     allow(webhook_attachment_fetcher).to receive(:execute).and_return(attachments)
     service.execute(
-      user_answers: user_answers, service_slug: submission.service_slug, submission_id: submission.decrypted_payload[:submission_id]
+      user_answers: user_answers, service_slug: submission.service_slug, payload_submission_id: submission.decrypted_payload[:submission_id]
     )
   end
 

--- a/spec/services/json_webhook_service_spec.rb
+++ b/spec/services/json_webhook_service_spec.rb
@@ -39,7 +39,7 @@ describe JsonWebhookService do
   let(:json_payload) do
     {
       serviceSlug: submission.service_slug,
-      submissionId: submission.decrypted_payload[:submission_id],
+      submissionId: submission.decrypted_payload[:submission]['submission_id'],
       submissionAnswers: user_answers,
       attachments: attachments
     }.to_json
@@ -49,7 +49,7 @@ describe JsonWebhookService do
     allow(webhook_destination_adapter).to receive(:send_webhook)
     allow(webhook_attachment_fetcher).to receive(:execute).and_return(attachments)
     service.execute(
-      user_answers: user_answers, service_slug: submission.service_slug, payload_submission_id: submission.decrypted_payload[:submission_id]
+      user_answers: user_answers, service_slug: submission.service_slug, payload_submission_id: submission.decrypted_payload[:submission]['submission_id']
     )
   end
 

--- a/spec/services/process_submission_service_spec.rb
+++ b/spec/services/process_submission_service_spec.rb
@@ -37,7 +37,6 @@ describe ProcessSubmissionService do
     # rubocop:disable RSpec/MultipleExpectations
     it 'sends email with csv attachment' do
       expect(submission_service_spy).to have_received(:execute) do |args|
-        expect(args[:submission_id]).to be_present
         expect(args[:action]).to eql(actions[0])
         expect(args[:attachments].length).to eq(1)
 
@@ -108,12 +107,6 @@ describe ProcessSubmissionService do
           expect(args[:attachments].length).to eq(attachments.length)
           attachment = args[:attachments].first
           expect(attachment.filename).to eq(attachments.first['filename'])
-        end
-      end
-
-      it 'passes the correct submission_id to the EmailOutputService' do
-        expect(submission_service_spy).to have_received(:execute) do |args|
-          expect(args[:submission_id]).to eq(submission.decrypted_payload[:submission]['submission_id'])
         end
       end
 
@@ -197,7 +190,7 @@ describe ProcessSubmissionService do
 
     it 'passes the correct submission_id as an argument' do
       expect(json_webhook_service_spy).to have_received(:execute) do |args|
-        expect(args[:submission_id]).to eq(submission.decrypted_payload[:submission]['submission_id'])
+        expect(args[:payload_submission_id]).to eq(submission.decrypted_payload[:submission]['submission_id'])
       end
     end
 


### PR DESCRIPTION
As a result of keeping track of submission email payloads we wanted to record the ID of the submission in the database with the EmailPayload.

The submission_id that the JSON and the Email Output Service use for end users is the submission_id from the payload received from the runner. This is not the same as the ID of the submission record in the database that is created for that given submission.

Here we rename the submission_id received from the payload to payload_submission_id. We really want to use the term submission_id when it relates to the ID of a Submission in the database. This will help us differentiate between the two types.

https://trello.com/c/248f4veP/476-stop-looping-submission-emails-that-have-been-successfully-sent