### PR TITLE
Associate Email Payloads to a Submission

### DIFF
--- a/app/models/email_payload.rb
+++ b/app/models/email_payload.rb
@@ -1,4 +1,6 @@
 class EmailPayload < ActiveRecord::Base
+  belongs_to :submission
+
   def decrypted_attachments
     EncryptionService.new.decrypt(attachments)
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,4 +1,6 @@
 class Submission < ActiveRecord::Base
+  has_many :email_payloads, dependent: :destroy
+
   def decrypted_payload
     EncryptionService.new.decrypt(payload).to_h
   end

--- a/app/services/db_sweeper.rb
+++ b/app/services/db_sweeper.rb
@@ -1,26 +1,9 @@
 class DbSweeper
   def call
-    vanquish_submissions
-    annihilate_email_payloads
+    Submission.where('created_at < ?', age_threshold).destroy_all
   end
 
-  private
-
-  def vanquish_submissions
-    Submission.where('created_at < ?', submission_age_threshold).destroy_all
-  end
-
-  def annihilate_email_payloads
-    EmailPayload.where('created_at < ?', email_payload_age_threshold)
-                .where.not(succeeded_at: nil)
-                .destroy_all
-  end
-
-  def submission_age_threshold
+  def age_threshold
     28.days.ago
-  end
-
-  def email_payload_age_threshold
-    7.days.ago
   end
 end

--- a/spec/factories/email_payload.rb
+++ b/spec/factories/email_payload.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :email_payload do
-    submission_id { SecureRandom.uuid }
+    submission_id {}
     attachments { [] }
     succeeded_at {}
+    to {}
   end
 end

--- a/spec/models/email_payload_spec.rb
+++ b/spec/models/email_payload_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe EmailPayload do
   describe 'decrypted_payload' do
+    let(:submission) { create(:submission) }
     let(:attachments) { %w[call me ishmael] }
     let(:to) { 'ahab@pequod.boat' }
     let(:encrypted_to) { EncryptionService.new.encrypt(to) }
@@ -9,6 +10,7 @@ RSpec.describe EmailPayload do
 
     let(:email_payload) do
       described_class.create!(
+        submission_id: submission.id,
         to: encrypted_to,
         attachments: encrypted_attachments
       )

--- a/spec/services/db_sweeper_spec.rb
+++ b/spec/services/db_sweeper_spec.rb
@@ -3,53 +3,31 @@ require 'rails_helper'
 RSpec.describe DbSweeper do
   describe '#call' do
     context 'when there are submissions over 28 days old' do
+      let(:thirty_day_submission) { create(:submission, created_at: 30.days.ago) }
+      let(:five_day_submission) { create(:submission, created_at: 5.days.ago) }
+
       before do
-        create(:submission, created_at: 30.days.ago)
-        create(:submission, created_at: 5.days.ago)
+        create(:email_payload, submission_id: thirty_day_submission.id)
+        create(:email_payload, submission_id: five_day_submission.id)
       end
 
-      it 'destroys the older submission records' do
+      it 'destroys the older submission records and associated email payload records' do
         expect do
           subject.call
-        end.to change(Submission, :count).by(-1)
+        end.to change(Submission, :count).by(-1).and change(EmailPayload, :count).by(-1)
       end
     end
 
     context 'when there are no submissions over 28 days old' do
+      let(:submission) { create(:submission, created_at: 5.days.ago) }
+
       before do
-        create(:submission, created_at: 5.days.ago)
+        create(:email_payload, submission_id: submission.id)
       end
 
-      it 'leaves submission records intact' do
-        expect do
-          subject.call
-        end.not_to change(Submission, :count)
-      end
-    end
-
-    context 'when there are email payloads over 7 days old' do
-      before do
-        create(:email_payload, created_at: 10.days.ago)
-        create(:email_payload, created_at: 10.days.ago, succeeded_at: 10.days.ago)
-        create(:email_payload, created_at: 5.days.ago, succeeded_at: 5.days.ago)
-      end
-
-      it 'destroys the older records unless email sending failed' do
-        expect do
-          subject.call
-        end.to change(EmailPayload, :count).by(-1)
-      end
-    end
-
-    context 'when there are no email payloads over 7 days old' do
-      before do
-        create(:email_payload, created_at: 5.days.ago)
-      end
-
-      it 'leaves email payload records intact' do
-        expect do
-          subject.call
-        end.not_to change(EmailPayload, :count)
+      it 'leaves submission and email payload records intact' do
+        expect(Submission.all.count).to eq(1)
+        expect(EmailPayload.all.count).to eq(1)
       end
     end
   end

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -24,7 +24,7 @@ describe EmailOutputService do
     )
   end
 
-  let(:submission_id) { SecureRandom.uuid }
+  let(:submission_id) { create(:submission).id }
   let(:payload_submission_id) { 'an-id-2323' }
 
   let(:email_service_mock) { class_double(EmailService) }


### PR DESCRIPTION
There shouldn't be any Email Payloads without a corresponding Submission so we may as well associate them.

We also want to clean up the Email Payloads at the same time as we do the Submissions.

Doing this also takes care of any potential dangling records that may arise from replaying Submissions where we have had to update any to email addresses.