### PR TITLE
Allow for the replay of submissions with attachments

### DIFF
--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -1,11 +1,12 @@
 class DownloadService
   attr_reader :attachments, :target_dir, :token, :access_token
 
-  def initialize(attachments:, target_dir: nil, token:, access_token:)
+  def initialize(attachments:, target_dir: nil, token:, access_token:, jwt_skew_override:)
     @attachments = attachments
     @target_dir = target_dir
     @token = token
     @access_token = access_token
+    @jwt_skew_override = jwt_skew_override
   end
 
   def download_in_parallel
@@ -30,11 +31,14 @@ class DownloadService
 
   private
 
+  attr_reader :jwt_skew_override
+
   def headers
     {
       'x-encrypted-user-id-and-token' => token,
-      'x-access-token-v2' => access_token
-    }
+      'x-access-token-v2' => access_token,
+      'x-jwt-skew-override' => jwt_skew_override
+    }.compact
   end
 
   def construct_request(url:, file_path:, headers: {})

--- a/app/services/process_submission_service.rb
+++ b/app/services/process_submission_service.rb
@@ -1,8 +1,9 @@
 class ProcessSubmissionService
   attr_reader :submission_id
 
-  def initialize(submission_id:)
+  def initialize(submission_id:, jwt_skew_override: nil)
     @submission_id = submission_id
+    @jwt_skew_override = jwt_skew_override
   end
 
   # rubocop:disable Metrics/MethodLength
@@ -49,12 +50,15 @@ class ProcessSubmissionService
 
   private
 
+  attr_reader :jwt_skew_override
+
   def download_attachments(attachments_payload, token, access_token)
     DownloadService.new(
       attachments: attachments_payload,
       target_dir: nil,
       token: token,
-      access_token: access_token
+      access_token: access_token,
+      jwt_skew_override: jwt_skew_override
     ).download_in_parallel
   end
 

--- a/lib/tasks/replay_submission.rake
+++ b/lib/tasks/replay_submission.rake
@@ -1,0 +1,49 @@
+namespace :replay_submission do
+  desc "
+  Replay a submission
+  Usage
+  rake replay_submission:process[<submission_id>]
+  "
+  task :process, [:submission_id] => :environment do |_t, args|
+    if args[:submission_id].nil?
+      puts 'Submission ID is required'
+    else
+      job = Delayed::Job.all.find { |j| j.handler.include?(args[:submission_id]) }
+      if job.nil?
+        puts "No job for submission ID #{args[:submission_id]}"
+      else
+        job.update(run_at: 10.seconds.from_now)
+        puts "Replayed job for job ID #{job.id} - submission ID #{args[:submission_id]}"
+      end
+    end
+  end
+
+  desc "
+  Replay a submission with attachments
+  Usage
+  rake replay_submission:with_attachments[<submission_id>,<jwt_skew_override>]
+  "
+  task :with_attachments, [:submission_id, :jwt_skew_override] => :environment do |_t, args|
+    if args[:submission_id].nil? || args[:jwt_skew_override].nil?
+      puts 'Submission ID is required' if args[:submission_id].nil?
+      puts 'JWT skew override is required' if args[:jwt_skew_override].nil?
+    else
+      old_job = Delayed::Job.all.find { |j| j.handler.include?(args[:submission_id]) }
+
+      if old_job.nil?
+        puts "No job for submission ID #{args[:submission_id]}"
+      else
+        Delayed::Job.enqueue(
+          ProcessSubmissionService.new(
+            submission_id: args[:submission_id],
+            jwt_skew_override: args[:jwt_skew_override]
+          )
+        )
+        puts "Queued new job for submission ID #{args[:submission_id]}"
+
+        old_job.destroy
+        puts "Destroyed previous delayed job #{old_job.id}"
+      end
+    end
+  end
+end

--- a/spec/services/download_service_spec.rb
+++ b/spec/services/download_service_spec.rb
@@ -26,7 +26,8 @@ describe DownloadService do
       described_class.new(attachments: attachments,
                           target_dir: target_dir,
                           token: token,
-                          access_token: access_token)
+                          access_token: access_token,
+                          jwt_skew_override: nil)
     end
 
     let(:path) { '/the/file/path' }
@@ -59,7 +60,8 @@ describe DownloadService do
         described_class.new(attachments: attachments,
                             target_dir: target_dir,
                             token: token,
-                            access_token: access_token)
+                            access_token: access_token,
+                            jwt_skew_override: nil)
       end
 
       let(:target_dir) { '/my/tmp/dir' }
@@ -75,7 +77,8 @@ describe DownloadService do
         described_class.new(attachments: attachments,
                             target_dir: path,
                             token: token,
-                            access_token: access_token)
+                            access_token: access_token,
+                            jwt_skew_override: nil)
       end
 
       let(:url1) { 'https://example.com/service/some-service/user/some-user/fingerprint' }
@@ -181,6 +184,23 @@ describe DownloadService do
           ]
         )
       end
+
+      context 'when a jwt skew override is supplied' do
+        subject(:downloader) do
+          described_class.new(attachments: attachments,
+                              target_dir: target_dir,
+                              token: token,
+                              access_token: access_token,
+                              jwt_skew_override: '600')
+        end
+
+        it 'sends the jwt skew override with the other headers' do
+          expected_headers = headers.merge('x-jwt-skew-override' => '600')
+          expect(downloader).to receive(:construct_request).with(url: url1, file_path: '/the/file/path/file.ext', headers: expected_headers)
+
+          downloader.download_in_parallel
+        end
+      end
     end
   end
 
@@ -189,7 +209,8 @@ describe DownloadService do
       described_class.new(attachments: attachments,
                           target_dir: target_dir,
                           token: token,
-                          access_token: access_token)
+                          access_token: access_token,
+                          jwt_skew_override: nil)
     end
 
     let(:mock_request) { instance_double(Typhoeus::Request, url: 'some_url') }


### PR DESCRIPTION
## What

In the event of a submission which has attachments failing to send an email the job is retried a few times and eventually will return a `403` error. This relates to the fact that the lifetime for the JWT is set to 60 seconds and if the submission cannot be processed within that time it will never be able to access any files uploaded by a user.

Given our infrastructure, and the fact that the JWT is generated by the Runner instead of the Submitter, it is not possible to retry a submission from an instance of a Submitter app unless we allow for a longer lifetime (skew as it's called in the filestore app) of the JWT.

This rake task enables us to override that leeway for that one submission replay allowing us to replay any jobs with attachments that have failed.

## Why

Failing submissions are unusual however it is very important that we retain the ability to retry once any underlying issues have been identified and fixed.

[Related Filestore PR](https://github.com/ministryofjustice/fb-user-filestore/pull/142)

https://trello.com/c/O95ENrYl/574-replay-failed-submissions-that-have-attachments