### PR TITLE
Pin Rubocop-rspec to 1.39.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '>= 3.8.0'
   gem 'rubocop', '~> 0.85.1'
-  gem 'rubocop-rspec', '~> 1.40'
+  gem 'rubocop-rspec', '1.39.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,14 +61,14 @@ GEM
     ansi (1.5.0)
     ast (2.4.1)
     aws-eventstream (1.1.0)
-    aws-partitions (1.328.0)
-    aws-sdk-core (3.99.0)
+    aws-partitions (1.329.0)
+    aws-sdk-core (3.99.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-ses (1.31.0)
-      aws-sdk-core (~> 3, >= 3.71.0)
+    aws-sdk-ses (1.31.1)
+      aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.4)
       aws-eventstream (~> 1.0, >= 1.0.2)
@@ -244,7 +244,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.0.3)
       parser (>= 2.7.0.1)
-    rubocop-rspec (1.40.0)
+    rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
@@ -312,7 +312,7 @@ DEPENDENCIES
   rails (~> 6.0.3)
   rspec-rails (>= 3.8.0)
   rubocop (~> 0.85.1)
-  rubocop-rspec (~> 1.40)
+  rubocop-rspec (= 1.39.0)
   sentry-raven
   simplecov
   simplecov-console
@@ -325,4 +325,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.0.2
+   2.1.4


### PR DESCRIPTION
This is temporary as the builds are failing.