### PR TITLE
Trigger acceptance tests when specs pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,12 +90,14 @@ workflows:
   version: 2
   test_and_build:
     jobs:
-      - trigger_acceptance_tests:
+      - test
+      - build_and_deploy_to_test:
+          requires:
+            - test
           filters:
             branches:
               only: master
-      - test
-      - build_and_deploy_to_test:
+      - trigger_acceptance_tests:
           requires:
             - test
           filters:


### PR DESCRIPTION
There probably is not a point for the acceptance tests to run if the
units tests in the submitter haven't passed so we may as well make that
a requirement.