### PR TITLE
Rubocop-rspec 1.40.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '>= 3.8.0'
   gem 'rubocop', '~> 0.85.1'
-  gem 'rubocop-rspec', '1.39.0'
+  gem 'rubocop-rspec', '~> 1.40.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.0.3)
       parser (>= 2.7.0.1)
-    rubocop-rspec (1.39.0)
+    rubocop-rspec (1.40.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
@@ -312,7 +312,7 @@ DEPENDENCIES
   rails (~> 6.0.3)
   rspec-rails (>= 3.8.0)
   rubocop (~> 0.85.1)
-  rubocop-rspec (= 1.39.0)
+  rubocop-rspec (~> 1.40.0)
   sentry-raven
   simplecov
   simplecov-console


### PR DESCRIPTION
The builds seem to be passing again. Let's try fixing it forward.