### PR TITLE
Add brakeman to the app and CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           command: docker-compose run --rm app bundle exec rubocop
       - run:
           name: security
-          command: docker-compose run --rm app bundle exec brakeman
+          command: docker-compose run --rm app bundle exec brakeman -q --no-pager
   test:
     working_directory: ~/circle
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
       - run:
           name: lint
           command: docker-compose run --rm app bundle exec rubocop
+      - run:
+          name: security
+          command: docker-compose run --rm app bundle exec brakeman
   test:
     working_directory: ~/circle
     docker:

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'typhoeus'
 gem 'tzinfo-data'
 
 group :development, :test do
+  gem 'brakeman'
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '>= 3.8.0'
   gem 'rubocop', '~> 0.85.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       aws-eventstream (~> 1.0, >= 1.0.2)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
+    brakeman (4.8.2)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.2)
@@ -305,6 +306,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-ses (~> 1.31.0)
   bootsnap (>= 1.1.0)
+  brakeman
   byebug
   daemons
   database_cleaner


### PR DESCRIPTION
## Context

This PR adds brakeman for security scanner the application.

You can read all warning types here:

https://brakemanscanner.org/docs/warning_types/

The security scanner will be run after the linting in the "verify" step.