### PR TITLE
Disable pentest step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,12 +127,6 @@ workflows:
   test_and_build:
     jobs:
       - test
-      - build_and_deploy_to_pentest:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
       - build_and_deploy_to_test:
           requires:
             - test


### PR DESCRIPTION
We do not want to keep changing the pentest environment while testing is ongoing. We can put the step back should we need to deploy out to it.