### PR TITLE
Remove rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ group :development, :test do
   gem 'rspec-rails', '>= 3.8.0'
   gem 'rubocop', '~> 0.85.1'
   gem 'rubocop-govuk'
-  gem 'rubocop-rspec', '1.40.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,6 @@ DEPENDENCIES
   rspec-rails (>= 3.8.0)
   rubocop (~> 0.85.1)
   rubocop-govuk
-  rubocop-rspec (= 1.40.0)
   sentry-raven
   simplecov
   simplecov-console


### PR DESCRIPTION
We already use rubocop-govuk of which rubocop is a dependency so we do not need to explicitly require it