### PR TITLE
Decrypt submission payloads

### DIFF
--- a/app/controllers/submission_controller.rb
+++ b/app/controllers/submission_controller.rb
@@ -29,11 +29,17 @@ class SubmissionController < ApplicationController
   end
 
   def payload
-    params.slice(
-      :meta,
-      :actions,
-      :submission,
-      :attachments
-    ).permit!
+    if params[:encrypted_submission]
+      decrypted_submission = JSON.parse(
+        JWE.decrypt(params[:encrypted_submission], submission_decryption_key)
+      )
+      params.merge(decrypted_submission).slice(:meta, :actions, :submission, :attachments).permit!
+    else
+      params.slice(:meta, :actions, :submission, :attachments).permit!
+    end
+  end
+
+  def submission_decryption_key
+    ENV['SUBMISSION_DECRYPTION_KEY']
   end
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -5,6 +5,7 @@
 Rails.application.config.filter_parameters += [
   :actions,
   :submission,
+  :encrypted_submission,
   :attachments,
   :password,
   :encrypted_user_id_and_token,

--- a/deploy/fb-submitter-chart/templates/deployment.yaml
+++ b/deploy/fb-submitter-chart/templates/deployment.yaml
@@ -81,6 +81,11 @@ spec:
               secretKeyRef:
                 name: fb-submitter-app-secrets-{{ .Values.environmentName }}
                 key: metrics_access_key
+          - name: SUBMISSION_DECRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-submitter-app-secrets-{{ .Values.environmentName }}
+                key: submission_decryption_key
       volumes:
         - name: tmp-files
           emptyDir: {}

--- a/deploy/fb-submitter-chart/templates/secrets.yaml
+++ b/deploy/fb-submitter-chart/templates/secrets.yaml
@@ -28,3 +28,4 @@ data:
   encryption_key: {{ .Values.encryption_key }}
   encryption_salt: {{ .Values.encryption_salt }}
   metrics_access_key: {{ .Values.metrics_access_key }}
+  submission_decryption_key: {{ .Values.submission_decryption_key }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       ENCRYPTION_KEY: 'i6USnzeRKljfLMPbRlB2E9oikURx4ou3'
       ENCRYPTION_SALT: 'lGlcn9HabIducdpwlSHcM06e9gFuIfS1Ogg5krtn1Fw='
       MAX_IAT_SKEW_SECONDS: 60
+      SUBMISSION_DECRYPTION_KEY: eRIF8glaggYMluja
     links:
       - db
 

--- a/spec/controllers/submission_controller_spec.rb
+++ b/spec/controllers/submission_controller_spec.rb
@@ -1,57 +1,102 @@
 require 'rails_helper'
 
 RSpec.describe SubmissionController, type: :controller do
-  let(:payload) do
+  let(:submission_decryption_key) { '58992847-4155-4c' }
+  let(:submission) do
     {
       meta: {
         submission_id: '123',
         submission_at: '2019-12-18T13:19:29.626Z'
       },
       actions: 1,
-      submission: {
-        submission_id: '123',
-        else: 1
-      },
+      submission: { submission_id: '123', else: 1 },
       attachments: [1, 2]
     }
   end
-
+  let(:encrypted_submission) do
+    JWE.encrypt(
+      JSON.generate(submission),
+      submission_decryption_key,
+      alg: 'dir'
+    )
+  end
+  let(:payload) do
+    {
+      service_slug: 'service-slug',
+      encrypted_user_id_and_token: 'encrypted-token',
+      encrypted_submission: encrypted_submission
+    }
+  end
   let(:headers) do
     {
       'content-type' => 'application/json',
       'x-access-token-v2' => token
     }
   end
-
   let(:token) { 'some-access-token' }
 
-  before do
-    request.headers.merge!(headers)
-    allow_any_instance_of(ApplicationController).to receive(:verify_token!)
-    post :create, body: payload.to_json, format: :json
+  context 'with encrypted payload' do
+    before do
+      allow(controller).to receive(:submission_decryption_key)
+        .and_return(submission_decryption_key)
+      request.headers.merge!(headers)
+      allow_any_instance_of(ApplicationController).to receive(:verify_token!)
+      post :create, body: payload.to_json, format: :json
+    end
+
+    after do
+      Submission.destroy_all
+    end
+
+    it 'creates a submission' do
+      expect(Submission.all.count).to eq(1)
+    end
+
+    it 'persists access token' do
+      expect(Submission.first.access_token).to eq(token)
+    end
+
+    it 'saves the payload into the submission' do
+      expect(Submission.first.decrypted_payload).to eq(
+        ActiveSupport::HashWithIndifferentAccess.new(submission)
+      )
+    end
+
+    it 'creates a delayed job' do
+      expect(Delayed::Job.all.count).to eq(1)
+    end
+
+    it 'marks delayed job as created' do
+      expect(response).to have_http_status(:created)
+    end
+
+    it 'returns valid json response' do
+      expect { JSON.parse(response.body) }.not_to raise_error
+    end
   end
 
-  it 'creates a submission' do
-    expect(Submission.all.count).to eq(1)
-  end
+  context 'with old payload' do
+    let(:old_payload) do
+      {
+        service_slug: 'service-slug',
+        encrypted_user_id_and_token: 'encrypted-token'
+      }.merge(submission)
+    end
 
-  it 'persists access token' do
-    expect(Submission.first.access_token).to eq(token)
-  end
+    before do
+      request.headers.merge!(headers)
+      allow_any_instance_of(ApplicationController).to receive(:verify_token!)
+      post :create, body: old_payload.to_json, format: :json
+    end
 
-  it 'saves the payload into the submission' do
-    expect(Submission.first.decrypted_payload).to eq(payload.deep_stringify_keys)
-  end
+    after do
+      Submission.destroy_all
+    end
 
-  it 'creates a delayed job' do
-    expect(Delayed::Job.all.count).to eq(1)
-  end
-
-  it 'marks delayed job as created' do
-    expect(response).to have_http_status(:created)
-  end
-
-  it 'returns valid json response' do
-    expect { JSON.parse(response.body) }.not_to raise_error
+    it 'saves the older style payload into the submission' do
+      expect(Submission.first.decrypted_payload).to eq(
+        ActiveSupport::HashWithIndifferentAccess.new(submission)
+      )
+    end
   end
 end


### PR DESCRIPTION
The runner now sends the submission as an encrypted JSON string. We need to continue to suppor the unecrypted version for a short period until the swap over is complete.

For the moment we continue to encrypt again before saving the submission payload to the submitter database.

https://trello.com/c/j6VCPRja/806-encrypt-between-the-runner-the-submitter

Co-authored-by: Tomas Destefi tomas.destefi@digital.justice.gov.uk
Co-authored-by: Matt Tei matt.tei@digital.justice.gov.uk
Co-authored-by: Natalie Seeto natalie.seeto@digital.justice.gov.uk