### PR TITLE
Add 256-CTR decryption to the submission payload

### DIFF
--- a/app/controllers/submission_controller.rb
+++ b/app/controllers/submission_controller.rb
@@ -30,16 +30,15 @@ class SubmissionController < ApplicationController
 
   def payload
     if params[:encrypted_submission]
-      decrypted_submission = JSON.parse(
-        JWE.decrypt(params[:encrypted_submission], submission_decryption_key)
+      decrypted_submission = SubmissionEncryption.new.decrypt(
+        params[:encrypted_submission]
       )
-      params.merge(decrypted_submission).slice(:meta, :actions, :submission, :attachments).permit!
+
+      params.merge(decrypted_submission).slice(
+        :meta, :actions, :submission, :attachments
+      ).permit!
     else
       params.slice(:meta, :actions, :submission, :attachments).permit!
     end
-  end
-
-  def submission_decryption_key
-    ENV['SUBMISSION_DECRYPTION_KEY']
   end
 end

--- a/app/services/submission_encryption.rb
+++ b/app/services/submission_encryption.rb
@@ -1,0 +1,31 @@
+class SubmissionEncryption
+  attr_reader :encrypted_submission, :cipher, :key, :iv
+
+  def initialize(key: ENV['SUBMISSION_DECRYPTION_KEY'])
+    @cipher = OpenSSL::Cipher::AES.new(256, :CTR)
+    @key = key
+    @iv = @key[0..15]
+  end
+
+  def encrypt(submission)
+    cipher.encrypt
+    cipher.key = key
+    cipher.iv = iv
+    result = cipher.update(submission.to_json)
+    result << cipher.final
+
+    Base64.encode64 result
+  end
+
+  def decrypt(encrypted_submission)
+    cipher.decrypt
+    cipher.key = key
+    cipher.iv = iv
+    raw_decrypted_submission = cipher.update(
+      Base64.decode64(encrypted_submission)
+    )
+    raw_decrypted_submission << cipher.final
+
+    JSON.parse(raw_decrypted_submission)
+  end
+end

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -9,7 +9,7 @@ describe 'UserData API', type: :request do
     let(:pdf_file_content) { 'pdf binary goes here' }
     let(:url) { '/submission' }
     let(:post_request) { post url, params: params.to_json, headers: headers }
-    let(:submission_decryption_key) { '58992847-4155-4c' }
+    let(:submission_decryption_key) { SecureRandom.uuid[0..31] }
 
     before do
       Delayed::Worker.delay_jobs = false
@@ -113,7 +113,9 @@ describe 'UserData API', type: :request do
           }
         end
         let(:encrypted_submission) do
-          JWE.encrypt(JSON.generate(payload), submission_decryption_key, alg: 'dir')
+          SubmissionEncryption.new(
+            key: submission_decryption_key
+          ).encrypt(payload)
         end
         let(:params) do
           {


### PR DESCRIPTION
[Trello Card](https://trello.com/c/j6VCPRja/806-encrypt-between-the-runner-the-submitter)

## Context

This PR adds the decryption of the submission payload **before** encrypting again to the database.
This adds more security into transporting data between the runner and the submitter.