### PR TITLE
Remove support for unencrypted payloads

### DIFF
--- a/app/controllers/submission_controller.rb
+++ b/app/controllers/submission_controller.rb
@@ -29,16 +29,12 @@ class SubmissionController < ApplicationController
   end
 
   def payload
-    if params[:encrypted_submission]
-      decrypted_submission = SubmissionEncryption.new.decrypt(
-        params[:encrypted_submission]
-      )
+    decrypted_submission = SubmissionEncryption.new.decrypt(
+      params[:encrypted_submission]
+    )
 
-      params.merge(decrypted_submission).slice(
-        :meta, :actions, :submission, :attachments
-      ).permit!
-    else
-      params.slice(:meta, :actions, :submission, :attachments).permit!
-    end
+    params.merge(decrypted_submission).slice(
+      :meta, :actions, :submission, :attachments
+    ).permit!
   end
 end

--- a/spec/controllers/submission_controller_spec.rb
+++ b/spec/controllers/submission_controller_spec.rb
@@ -72,29 +72,4 @@ RSpec.describe SubmissionController, type: :controller do
       expect { JSON.parse(response.body) }.not_to raise_error
     end
   end
-
-  context 'with old payload' do
-    let(:old_payload) do
-      {
-        service_slug: 'service-slug',
-        encrypted_user_id_and_token: 'encrypted-token'
-      }.merge(submission)
-    end
-
-    before do
-      request.headers.merge!(headers)
-      allow_any_instance_of(ApplicationController).to receive(:verify_token!)
-      post :create, body: old_payload.to_json, format: :json
-    end
-
-    after do
-      Submission.destroy_all
-    end
-
-    it 'saves the older style payload into the submission' do
-      expect(Submission.first.decrypted_payload).to eq(
-        ActiveSupport::HashWithIndifferentAccess.new(submission)
-      )
-    end
-  end
 end


### PR DESCRIPTION
We no longer need to support unencrypted payloads received from the Runner.