### PR TITLE
Use workers repository

### DIFF
--- a/deploy/fb-submitter-chart/templates/deployment.yaml
+++ b/deploy/fb-submitter-chart/templates/deployment.yaml
@@ -110,8 +110,8 @@ spec:
     spec:
       serviceAccountName: "formbuilder-submitter-workers-{{ .Values.environmentName }}"
       containers:
-      - name: "fb-submitter-worker"
-        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-submitter-worker:{{ .Values.circleSha1 }}"
+      - name: "fb-submitter-workers"
+        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-submitter-workers:{{ .Values.circleSha1 }}"
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp


### PR DESCRIPTION
This is to adjust a naming discrepancy between the ECR repositories and the image name. We have decided to move to using the plural as we think there is less risk in downtime doing it this way.