### PR TITLE
Update dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -14,7 +14,7 @@ update_configs:
     - tomas-stefano
     - brenetic
   - package_manager: "docker"
-    directory: "/docker/worker"
+    directory: "/docker/workers"
     update_schedule: "daily"
     default_reviewers:
     - tomas-stefano


### PR DESCRIPTION
We changed the directory which contains the worker dockerfile to be the plural 'workers'.