### PR TITLE
Run acceptance tests in their own step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,15 +26,15 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - add_ssh_keys:
+      - add_ssh_keys: &ssh_keys
           fingerprints:
             - "5d:c8:80:1b:1a:82:af:e0:30:26:d1:62:37:7e:c9:c1"
-      - run:
+      - run: &base_environment_variables
           name: Setup base environment variable
           command: |
             echo "export BUILD_SHA=$CIRCLE_SHA1" >> $BASH_ENV
             echo "export SSH_FILE_FOR_SECRETS=~/.ssh/id_rsa_5dc8801b1a82afe03026d162377ec9c1" >> $BASH_ENV
-      - run:
+      - run: &deploy_scripts
           name: cloning deploy scripts
           command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
       - run:
@@ -64,17 +64,9 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - add_ssh_keys:
-          fingerprints:
-            - "5d:c8:80:1b:1a:82:af:e0:30:26:d1:62:37:7e:c9:c1"
-      - run:
-          name: Setup base environment variable
-          command: |
-            echo "export BUILD_SHA=$CIRCLE_SHA1" >> $BASH_ENV
-            echo "export SSH_FILE_FOR_SECRETS=~/.ssh/id_rsa_5dc8801b1a82afe03026d162377ec9c1" >> $BASH_ENV
-      - run:
-          name: cloning deploy scripts
-          command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
+      - add_ssh_keys: *ssh_keys
+      - run: *base_environment_variables
+      - run: *deploy_scripts
       - run:
           name: build and push docker images
           environment:
@@ -96,16 +88,16 @@ jobs:
             DEPLOYMENT_ENV: production
             K8S_NAMESPACE: formbuilder-platform-live-production
           command: './deploy-scripts/bin/deploy'
-  trigger_acceptance_tests:
-    working_directory: ~/circle/git/fb-submitter
+  acceptance_tests:
     docker: *ecr_image
+    resource_class: large
     steps:
+      - setup_remote_docker
+      - run: *deploy_scripts
       - run:
-          name: cloning deploy scripts
-          command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
-      - run:
-          name: "Trigger Acceptance Tests"
+          name: Run acceptance tests
           command: './deploy-scripts/bin/acceptance_tests'
+
 
 workflows:
   version: 2
@@ -119,7 +111,7 @@ workflows:
             branches:
               only:
                 - master
-      - trigger_acceptance_tests:
+      - acceptance_tests:
           requires:
             - build_and_deploy_to_test
           filters:
@@ -128,7 +120,7 @@ workflows:
       - confirm_live_deploy:
           type: approval
           requires:
-            - trigger_acceptance_tests
+            - acceptance_tests
       - build_and_deploy_to_live:
           requires:
             - confirm_live_deploy


### PR DESCRIPTION
We no longer want to trigger the acceptance tests via the API

https://trello.com/c/BxIV1rkx/931-make-acceptance-tests-run-inside-each-deployment