### PR TITLE
Pdf generator/content negotiation

### DIFF
--- a/app/services/adapters/pdf_api.rb
+++ b/app/services/adapters/pdf_api.rb
@@ -20,7 +20,11 @@ module Adapters
     private
 
     def headers
-      { 'x-access-token-v2' => token }
+      {
+        'x-access-token-v2' => token,
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json'
+      }
     end
 
     attr_reader :root_url, :token

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
   worker:
     build:
       context: .
-      dockerfile: ./docker/worker/Dockerfile
+      dockerfile: ./docker/workers/Dockerfile
     environment:
       DATABASE_URL: "postgres://postgres:password@db/submitter_local"
       NOTIFY_EMAIL_GENERIC: '46a72b64-9541-4000-91a7-fa8a3fa10bf9'

--- a/spec/services/adapters/pdf_api_spec.rb
+++ b/spec/services/adapters/pdf_api_spec.rb
@@ -26,7 +26,11 @@ describe Adapters::PdfApi do
   end
 
   let(:expected_headers) do
-    { 'x-access-token-v2' => 'some-token' }
+    {
+      'x-access-token-v2' => 'some-token',
+      'Accept' => 'application/json',
+      'Content-Type' => 'application/json'
+    }
   end
 
   before do


### PR DESCRIPTION
Make submitter requests to PDF sending the content type as json.

This makes sure that submissions are processed whenever the format inside of the payload.