### PR TITLE
Revert Sentry back to 3.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,7 +259,7 @@ GEM
     rubocop-rspec (1.42.0)
       rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
-    sentry-raven (3.1.1)
+    sentry-raven (3.0.4)
       faraday (>= 1.0)
     shellany (0.0.1)
     simplecov (0.19.1)


### PR DESCRIPTION
This is temporary as there is an issue with the Sentry gem:

https://github.com/getsentry/sentry-ruby/issues/1041

that looks like it will be fixed in version 4:

https://github.com/getsentry/sentry-ruby/pull/1057

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>