### PR TITLE
Allow replay tasks to accept multiple session IDs

### DIFF
--- a/lib/tasks/replay_submission.rake
+++ b/lib/tasks/replay_submission.rake
@@ -1,48 +1,56 @@
 namespace :replay_submission do
   desc "
-  Replay a submission
+  Replay submissions
+  For more than one submission ID use space separated IDs
   Usage
-  rake replay_submission:process[<submission_id>]
+  rake replay_submission:process[<submission_ids>]
   "
-  task :process, [:submission_id] => :environment do |_t, args|
-    if args[:submission_id].nil?
-      puts 'Submission ID is required'
+  task :process, [:submission_ids] => :environment do |_t, args|
+    if args[:submission_ids].nil?
+      puts 'At least one Submission ID is required'
     else
-      job = Delayed::Job.all.find { |j| j.handler.include?(args[:submission_id]) }
-      if job.nil?
-        puts "No job for submission ID #{args[:submission_id]}"
-      else
-        job.update!(run_at: 10.seconds.from_now)
-        puts "Replayed job for job ID #{job.id} - submission ID #{args[:submission_id]}"
+      submission_ids = args[:submission_ids].split(' ')
+      submission_ids.each do |submission_id|
+        job = Delayed::Job.all.find { |j| j.handler.include?(submission_id) }
+        if job.nil?
+          puts "No job for submission ID #{submission_id}"
+        else
+          job.update!(run_at: 10.seconds.from_now)
+          puts "Replayed job for job ID #{job.id} - submission ID #{submission_id}"
+        end
       end
     end
   end
 
   desc "
-  Replay a submission with attachments
+  Replay submissions with attachments
+  For more than one submission ID use space separated IDs
   Usage
   rake replay_submission:with_attachments[<submission_id>,<jwt_skew_override>]
   "
-  task :with_attachments, [:submission_id, :jwt_skew_override] => :environment do |_t, args|
-    if args[:submission_id].nil? || args[:jwt_skew_override].nil?
-      puts 'Submission ID is required' if args[:submission_id].nil?
+  task :with_attachments, [:submission_ids, :jwt_skew_override] => :environment do |_t, args|
+    if args[:submission_ids].nil? || args[:jwt_skew_override].nil?
+      puts 'At least one Submission ID is required' if args[:submission_ids].nil?
       puts 'JWT skew override is required' if args[:jwt_skew_override].nil?
     else
-      old_job = Delayed::Job.all.find { |j| j.handler.include?(args[:submission_id]) }
+      submission_ids = args[:submission_ids].split(' ')
+      submission_ids.each do |submission_id|
+        old_job = Delayed::Job.all.find { |j| j.handler.include?(submission_id) }
 
-      if old_job.nil?
-        puts "No job for submission ID #{args[:submission_id]}"
-      else
-        Delayed::Job.enqueue(
-          ProcessSubmissionService.new(
-            submission_id: args[:submission_id],
-            jwt_skew_override: args[:jwt_skew_override]
+        if old_job.nil?
+          puts "No job for submission ID #{submission_id}"
+        else
+          Delayed::Job.enqueue(
+            ProcessSubmissionService.new(
+              submission_id: submission_id,
+              jwt_skew_override: args[:jwt_skew_override]
+            )
           )
-        )
-        puts "Queued new job for submission ID #{args[:submission_id]}"
+          puts "Queued new job for submission ID #{submission_id}"
 
-        old_job.destroy!
-        puts "Destroyed previous delayed job #{old_job.id}"
+          old_job.destroy!
+          puts "Destroyed previous delayed job #{old_job.id}"
+        end
       end
     end
   end


### PR DESCRIPTION
Sometimes we need to be able to replay many failed Delayed Jobs. Here we
allow multiple submission IDs to be passed into the rake tasks separated
by spaces.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>