### PR TITLE
Replay only a single failed submission

### DIFF
--- a/lib/tasks/replay_submission.rake
+++ b/lib/tasks/replay_submission.rake
@@ -1,82 +1,74 @@
-namespace :replay_submissions do
+namespace :replay_submission do
   desc "
-  Replay submissions
-  For more than one submission ID use space separated IDs
+  Replay a submission
   Usage
-  rake replay_submissions:process[<submission_ids>]
+  rake replay_submission:process[<submission_id>]
   "
-  task :process, [:submission_ids] => :environment do |_t, args|
-    if args[:submission_ids].nil?
-      puts 'At least one Submission ID is required'
+  task :process, [:submission_id] => :environment do |_t, args|
+    if args[:submission_id].nil?
+      puts 'Submission ID is required'
     else
-      submission_ids = args[:submission_ids].split(' ')
-      submission_ids.each do |submission_id|
-        job = Delayed::Job.all.find { |j| j.handler.include?(submission_id) }
-        if job.nil?
-          puts "No job for submission ID #{submission_id}"
-        else
-          job.update!(run_at: 10.seconds.from_now)
-          puts "Replayed job for job ID #{job.id} - submission ID #{submission_id}"
-        end
+      job = Delayed::Job.all.find { |j| j.handler.include?(args[:submission_id]) }
+      if job.nil?
+        puts "No job for submission ID #{args[:submission_id]}"
+      else
+        job.update!(run_at: 10.seconds.from_now)
+        puts "Replayed job for job ID #{job.id} - submission ID #{args[:submission_id]}"
       end
     end
   end
 
   desc "
-  Replay submissions with attachments
-  For more than one submission ID use space separated IDs
+  Replay a submission with attachments
   Usage
-  rake replay_submissions:with_attachments[<submission_ids>,<jwt_skew_override>]
+  rake replay_submission:with_attachments[<submission_id>,<jwt_skew_override>]
   "
-  task :with_attachments, [:submission_ids, :jwt_skew_override] => :environment do |_t, args|
-    if args[:submission_ids].nil? || args[:jwt_skew_override].nil?
-      puts 'At least one Submission ID is required' if args[:submission_ids].nil?
+  task :with_attachments, [:submission_id, :jwt_skew_override] => :environment do |_t, args|
+    if args[:submission_id].nil? || args[:jwt_skew_override].nil?
+      puts 'Submission ID is required' if args[:submission_id].nil?
       puts 'JWT skew override is required' if args[:jwt_skew_override].nil?
     else
-      submission_ids = args[:submission_ids].split(' ')
-      submission_ids.each do |submission_id|
-        old_job = Delayed::Job.all.find { |j| j.handler.include?(submission_id) }
+      old_job = Delayed::Job.all.find { |j| j.handler.include?(args[:submission_id]) }
 
-        if old_job.nil?
-          puts "No job for submission ID #{submission_id}"
-        else
-          Delayed::Job.enqueue(
-            ProcessSubmissionService.new(
-              submission_id: submission_id,
-              jwt_skew_override: args[:jwt_skew_override]
-            )
+      if old_job.nil?
+        puts "No job for submission ID #{args[:submission_id]}"
+      else
+        Delayed::Job.enqueue(
+          ProcessSubmissionService.new(
+            submission_id: args[:submission_id],
+            jwt_skew_override: args[:jwt_skew_override]
           )
-          puts "Queued new job for submission ID #{submission_id}"
+        )
+        puts "Queued new job for submission ID #{args[:submission_id]}"
 
-          old_job.destroy!
-          puts "Destroyed previous delayed job #{old_job.id}"
-        end
+        old_job.destroy!
+        puts "Destroyed previous delayed job #{old_job.id}"
       end
     end
   end
 end
 
-namespace :replay_hmcts_adapter_submissions do
+namespace :replay_hmcts_adapter_submission do
   desc "
-  Replay failed HMCTS submissions
-  For more than one submission ID use space separated IDs
+  Replay failed HMCTS submission
   Usage
-  rake replay_hmcts_adapter_submissions:process[<submission_ids>]
+  rake replay_hmcts_adapter_submission:process[<submission_id>]
   "
-  task :process, [:submission_ids] => :environment do |_t, args|
-    if args[:submission_ids].nil?
+  task :process, [:submission_id] => :environment do |_t, args|
+    if args[:submission_id].nil?
       puts 'At least one Submission ID is required'
     else
-      payload_submission_ids = args[:submission_ids].split(' ')
-      submissions = Submission.all.select do |s|
-        s.decrypted_payload['meta']['submission_id'].in?(payload_submission_ids)
+      submission = Submission.all.find do |s|
+        s.decrypted_payload['meta']['submission_id'] == args[:submission_id]
       end
 
-      submissions.each do |submission|
+      if submission
         Delayed::Job.enqueue(
           ProcessSubmissionService.new(submission_id: submission.id)
         )
         puts "Queued new job for submission ID #{submission.id}"
+      else
+        puts "Unable to find matching Submission for ID #{args[:submission_id]}"
       end
     end
   end


### PR DESCRIPTION
Unfortunately it is not possible to pass space separated IDs to the rake tasks. So revert them back to only replaying a single submission.