### PR TITLE
Add submission decryption to key to workers container

### DIFF
--- a/deploy/fb-submitter-chart/templates/deployment.yaml
+++ b/deploy/fb-submitter-chart/templates/deployment.yaml
@@ -223,6 +223,11 @@ spec:
               secretKeyRef:
                 name: fb-submitter-app-secrets-{{ .Values.environmentName }}
                 key: metrics_access_key
+          - name: SUBMISSION_DECRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-submitter-app-secrets-{{ .Values.environmentName }}
+                key: submission_decryption_key
       volumes:
         - name: tmp-files
           emptyDir: {}


### PR DESCRIPTION
The submission decryption key is also required by the worker in order to process a submission that is received