### PR TITLE
Saves the service slug in v2

### DIFF
--- a/app/controllers/v2/submissions_controller.rb
+++ b/app/controllers/v2/submissions_controller.rb
@@ -9,7 +9,8 @@ module V2
     def create
       @submission = Submission.create!(
         payload: SubmissionEncryption.new.encrypt(decrypted_submission),
-        access_token: access_token
+        access_token: access_token,
+        service_slug: submission_params[:service_slug]
       )
 
       V2::ProcessSubmissionJob.perform_later(
@@ -20,7 +21,10 @@ module V2
     end
 
     def submission_params
-      params.permit(:encrypted_submission)
+      params.slice(
+        :encrypted_submission,
+        :service_slug
+      ).permit!
     end
 
     def access_token

--- a/spec/requests/v2/submissions_spec.rb
+++ b/spec/requests/v2/submissions_spec.rb
@@ -61,7 +61,8 @@ describe 'V2 Submissions endpoint', type: :request do
           {
             encrypted_submission: SubmissionEncryption.new(
               key: submission_decryption_key
-            ).encrypt(valid_submission_payload)
+            ).encrypt(valid_submission_payload),
+            service_slug: service_slug
           }
         end
 
@@ -82,10 +83,12 @@ describe 'V2 Submissions endpoint', type: :request do
           expect(submission.decrypted_submission).to eq(valid_submission_payload)
         end
 
-        it 'saves the submission access token' do
+        it 'saves the submission attributes' do
           post_request
           submission = Submission.last
-          expect(submission.try(:access_token)).to eq(access_token)
+          expect(submission).not_to be_nil
+          expect(submission.access_token).to eq(access_token)
+          expect(submission.service_slug).to eq(service_slug)
         end
 
         it 'creates a V2 Job to be processed asynchronously' do


### PR DESCRIPTION
[Trello card](https://trello.com/c/9CqrcRCv/1492-internal-bug-we-are-not-saving-the-service-in-our-submitter-app)

## Context

We are not saving the service slug in the submitter for v2 and this could be a problem or more difficult to identify
which service belongs to the submission.