### PR TITLE
Exclude metrics endpoint from Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,4 @@
-EXCLUDE_PATHS = %w[/health].freeze
+EXCLUDE_PATHS = %w[/health /metrics].freeze
 
 Sentry.init do |config|
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]


### PR DESCRIPTION
The metrics endpoint can be excluded from Sentry performance monitoring
for now. It is just generating extra noise.