### PR TITLE
Add include_attachments to v2 submissions schema

### DIFF
--- a/schemas/submission_payload.json
+++ b/schemas/submission_payload.json
@@ -84,6 +84,10 @@
         "include_pdf": {
           "type": "boolean",
           "default": true
+        },
+        "include_attachments": {
+          "type": "boolean",
+          "default": true
         }
       },
       "required": [


### PR DESCRIPTION
Now that we are doing file upload we need to allow for the
include_attachments property to exist in the submission payloads.

Currently the editor UI does not allow for the user to enable or disable
this so it will be there by default.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>