### PR TITLE
Make attachments property not required

### DIFF
--- a/schemas/submission_payload.json
+++ b/schemas/submission_payload.json
@@ -53,8 +53,7 @@
     "service",
     "meta",
     "actions",
-    "pages",
-    "attachments"
+    "pages"
   ],
   "additionalProperties": false,
   "definitions": {


### PR DESCRIPTION
The submission payload needs to accept submissions without attachments
in the short term as well as ones with attachments.

We will add the attachments property back to required a little later.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>