### PR TITLE
Add "attachments" as required back to json schemas for v2 submissions

### DIFF
--- a/schemas/submission_payload.json
+++ b/schemas/submission_payload.json
@@ -56,7 +56,8 @@
     "service",
     "meta",
     "actions",
-    "pages"
+    "pages",
+    "attachments"
   ],
   "additionalProperties": false,
   "definitions": {


### PR DESCRIPTION
This adds attachments back as required. This is to be merged after the runner is released to live.