### PR TITLE
Define rolling update strategy for deployments

### DIFF
--- a/deploy/fb-submitter-chart/templates/deployment.yaml
+++ b/deploy/fb-submitter-chart/templates/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
   namespace: formbuilder-platform-{{ .Values.environmentName }}
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: "fb-submitter-api-{{ .Values.environmentName }}"
@@ -98,6 +103,11 @@ metadata:
   namespace: formbuilder-platform-{{ .Values.environmentName }}
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: "fb-submitter-workers-{{ .Values.environmentName }}"


### PR DESCRIPTION
This explicitly sets the strategy for the deployments to be a rolling
update.

`maxSurge: 100%` means that a complete additional copy of the deployment will
be created before any of the old pods are terminated

`maxUnavailable: 50%` means the cluster will only allow at most half of the
pods to be unavailable