### PR TITLE
Make v2 submissions replayable

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -10,4 +10,14 @@ class Submission < ActiveRecord::Base
   def decrypted_submission
     SubmissionEncryption.new.decrypt(payload)
   end
+
+  # @return true if can decrypt the submission in v2
+  # @return false otherwise
+  #
+  def v2?
+    decrypted_submission
+    true
+  rescue StandardError
+    false
+  end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Submission do
     it 'decrypts the payload' do
       expect(submission.decrypted_payload).to eq(decrypted_payload)
     end
+
+    it 'returns false for v2' do
+      expect(submission).not_to be_v2
+    end
   end
 
   describe '#decrypted_submission' do
@@ -34,6 +38,10 @@ RSpec.describe Submission do
 
     it 'decrypts the payload' do
       expect(submission.decrypted_submission).to eq(decrypted_payload.stringify_keys)
+    end
+
+    it 'returns true for v2' do
+      expect(submission).to be_v2
     end
   end
 end


### PR DESCRIPTION
## Context

Make it possible to replay jobs in the v2 submissions (new runner submissions).

Simple solution but annoying to reproduce (make a failing job and replay).