### PR TITLE
Ignore concurrent migrations

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -32,4 +32,4 @@ EXPOSE $APP_PORT
 USER ${UID}
 
 ARG RAILS_ENV=production
-CMD bundle exec rake db:migrate && bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0
+CMD bundle exec rake db:migrate:ignore_concurrent && bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0

--- a/lib/tasks/migrate_ignore_concurrent.rake
+++ b/lib/tasks/migrate_ignore_concurrent.rake
@@ -1,0 +1,15 @@
+namespace :db do
+  namespace :migrate do
+    desc 'Run db:migrate but ignore ActiveRecord::ConcurrentMigrationError errors'
+    task ignore_concurrent: :environment do
+      # DB migrations are called as the entry command in the Dockerfile
+      # Since we have multiple pods for the Submitter we only need the first migration
+      # to run and any proceeding ActiveRecord::ConcurrentMigrationError
+      # can rescued instead of sending a Sentry alert.
+
+      Rake::Task['db:migrate'].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Move along
+    end
+  end
+end


### PR DESCRIPTION
This will call another migration rake task first. If there are any other
database migration tasks running it will ignore and continue