### PR TITLE
Enable receipt of CSV submissions from the V2 Runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: test
-          command: docker-compose run --rm app bundle exec rspec
+          command: docker-compose build && docker-compose run --rm app bundle exec rspec
       - slack/status: *slack_status
   lint:
     working_directory: ~/circle

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -4,41 +4,36 @@ module V2
 
     def perform(submission_id:, jwt_skew_override: nil)
       submission = Submission.find(submission_id)
-
-      decrypted_submission = submission.decrypted_submission.merge(
-        'submission_id' => submission.id
-      )
-
-      pdf_api_gateway = Adapters::PdfApi.new(
-        root_url: ENV.fetch('PDF_GENERATOR_ROOT_URL'),
-        token: submission.access_token
-      )
-      pdf_attachment = GeneratePdfContent.new(
-        pdf_api_gateway: pdf_api_gateway,
-        payload: PdfPayloadTranslator.new(decrypted_submission).to_h
-      ).execute
+      decrypted_submission = submission.decrypted_submission.merge('submission_id' => submission.id)
 
       decrypted_submission['actions'].each do |action|
-        next unless action['kind'] == 'email'
+        case action['kind']
+        when 'email'
+          pdf_api_gateway = Adapters::PdfApi.new(
+            root_url: ENV.fetch('PDF_GENERATOR_ROOT_URL'),
+            token: submission.access_token
+          )
+          pdf_attachment = GeneratePdfContent.new(
+            pdf_api_gateway: pdf_api_gateway,
+            payload: PdfPayloadTranslator.new(decrypted_submission).to_h
+          ).execute
 
-        attachments = download_attachments(
-          decrypted_submission['attachments'],
-          submission.encrypted_user_id_and_token,
-          submission.access_token,
-          jwt_skew_override
-        )
+          attachments = download_attachments(
+            decrypted_submission['attachments'],
+            submission.encrypted_user_id_and_token,
+            submission.access_token,
+            jwt_skew_override
+          )
 
-        EmailOutputService.new(
-          emailer: EmailService,
-          attachment_generator: AttachmentGenerator.new,
-          encryption_service: EncryptionService.new,
-          submission_id: submission.id,
-          payload_submission_id: submission.id
-        ).execute(
-          action: action.symbolize_keys,
-          attachments: attachments,
-          pdf_attachment: pdf_attachment
-        )
+          send_email(submission: submission, action: action, attachments: attachments, pdf_attachment: pdf_attachment)
+        when 'csv'
+          payload_service = V2::SubmissionPayloadService.new(decrypted_submission)
+          csv_attachment = V2::GenerateCsvContent.new(payload_service: payload_service).execute
+
+          send_email(submission: submission, action: action, attachments: [csv_attachment])
+        else
+          Rails.logger.warn "Unknown action type '#{action}' for submission id #{submission.id}"
+        end
       end
     end
 
@@ -50,6 +45,20 @@ module V2
         jwt_skew_override: jwt_skew_override,
         target_dir: nil
       ).download
+    end
+
+    def send_email(submission:, action:, attachments:, pdf_attachment: nil)
+      EmailOutputService.new(
+        emailer: EmailService,
+        attachment_generator: AttachmentGenerator.new,
+        encryption_service: EncryptionService.new,
+        submission_id: submission.id,
+        payload_submission_id: submission.id
+      ).execute(
+        action: action.symbolize_keys,
+        attachments: attachments,
+        pdf_attachment: pdf_attachment
+      )
     end
   end
 end

--- a/app/services/v2/generate_csv_content.rb
+++ b/app/services/v2/generate_csv_content.rb
@@ -1,0 +1,70 @@
+require 'csv'
+require 'tempfile'
+
+module V2
+  class GenerateCsvContent
+    FIXED_HEADERS = %w[submission_id submission_at].freeze
+    DATA_UNAVAILABLE = 'Data not available in CSV format'.freeze
+
+    def initialize(payload_service:)
+      @payload_service = payload_service
+    end
+
+    def execute
+      tmp_csv = generate_temp_file
+      generate_attachment_object(tmp_csv)
+    end
+
+    private
+
+    attr_reader :payload_service
+
+    def generate_temp_file
+      tmp_csv = Tempfile.new
+
+      CSV.open(tmp_csv.path, 'w') do |csv|
+        csv_contents.each { |row| csv << row }
+      end
+
+      tmp_csv.rewind
+      tmp_csv
+    end
+
+    def csv_contents
+      return @csv_contents if @csv_contents
+
+      @csv_contents = []
+      @csv_contents << csv_headers
+      @csv_contents << csv_data
+    end
+
+    def answer_values
+      payload_service.user_answers.values.map do |value|
+        value.is_a?(Hash) || value.is_a?(Array) ? DATA_UNAVAILABLE : value
+      end
+    end
+
+    def csv_data
+      data = []
+
+      data << payload_service.submission_id
+      data << payload_service.submission_at.iso8601(3)
+      data.concat(answer_values)
+
+      data
+    end
+
+    def csv_headers
+      FIXED_HEADERS + payload_service.user_answers.keys
+    end
+
+    def generate_attachment_object(tmp_csv)
+      attachment = Attachment.new(
+        filename: "#{payload_service.submission_id}-answers.csv",
+        mimetype: 'text/csv'
+      )
+      attachment.file = tmp_csv
+      attachment
+    end
+  end
+end

--- a/app/services/v2/submission_payload_service.rb
+++ b/app/services/v2/submission_payload_service.rb
@@ -1,0 +1,28 @@
+module V2
+  class SubmissionPayloadService
+    attr_reader :payload
+
+    def initialize(payload)
+      @payload = payload
+    end
+
+    def submission_id
+      payload['submission_id']
+    end
+
+    def submission_at
+      date_string = payload.dig('meta', 'submission_at')
+      return Time.zone.now if date_string.blank?
+
+      Time.zone.parse(date_string)
+    end
+
+    def user_answers
+      payload['pages'].each_with_object({}) do |page, hash|
+        page['answers'].each do |answer|
+          hash[answer['field_id']] = answer['answer']
+        end
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,8 @@ module FbSubmitter
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    config.autoload_paths << "#{root}/app/value_objects"
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/schemas/submission_payload.json
+++ b/schemas/submission_payload.json
@@ -30,6 +30,9 @@
         },
         "pdf_subheading": {
           "type": "string"
+        },
+        "submission_at": {
+          "type": "string"
         }
       }
     },
@@ -64,6 +67,7 @@
         "kind": {
           "type": "string",
           "enum": [
+            "csv",
             "email",
             "json"
           ]

--- a/spec/fixtures/payloads/valid_submission.json
+++ b/spec/fixtures/payloads/valid_submission.json
@@ -15,7 +15,17 @@
       "from":"\"Email Output Acceptance Test Service\" <moj-online@digital.justice.gov.uk>",
       "subject":"Email Output Acceptance Test submission: fc242acb-c03f-439e-b41d-bec76fa0f032",
       "email_body":"Please find an application attached",
-      "include_pdf":true
+      "include_pdf":true,
+      "include_attachments": true
+    },
+    {
+      "kind":"csv",
+      "to": "captain.needa@star-destroyer.com,admiral.piett@star-destroyer.com",
+      "from":"\"Email Output Acceptance Test Service\" <moj-online@digital.justice.gov.uk>",
+      "subject":"CSV Output Acceptance Test submission: fc242acb-c03f-439e-b41d-bec76fa0f032",
+      "email_body":"",
+      "include_pdf":true,
+      "include_attachments": false
     }
   ],
   "pages": [

--- a/spec/services/v2/generate_csv_content_spec.rb
+++ b/spec/services/v2/generate_csv_content_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe V2::GenerateCsvContent do
+  subject(:generate_csv_content) { described_class.new(payload_service: payload_service) }
+
+  let(:payload_service) do
+    V2::SubmissionPayloadService.new(payload)
+  end
+  let(:submission_at) { Time.zone.now.iso8601(3) }
+
+  let(:payload) do
+    {
+      'meta' => { 'submission_at' => submission_at },
+      'service' => { 'id' => SecureRandom.uuid },
+      'pages' => [
+        {
+          'heading' => 'Your name',
+          'answers' => [
+            {
+              'field_id' => 'name_text_1',
+              'answer' => 'Stormtrooper'
+            },
+            {
+              'field_id' => 'name_text_2',
+              'answer' => 'FN-some-last-name'
+            }
+          ]
+        },
+        {
+          'heading' => '',
+          'answers' => [
+            {
+              'field_id' => 'your-email-address_text_1',
+              'answer' => 'fb-acceptance-tests@digital.justice.gov.uk'
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  context 'when requesting a csv with a submission' do
+    let(:expected_column_0) do
+      %w[
+        submission_id
+        submission_at
+        name_text_1
+        name_text_2
+        your-email-address_text_1
+      ]
+    end
+    let(:expected_column_1) do
+      [
+        payload_service.submission_id,
+        submission_at,
+        'Stormtrooper',
+        'FN-some-last-name',
+        'fb-acceptance-tests@digital.justice.gov.uk'
+      ]
+    end
+
+    it 'returns an Attachment object' do
+      result = generate_csv_content.execute
+      expect(result.class).to eq(Attachment)
+    end
+
+    it 'creates the correct file name and type' do
+      result = generate_csv_content.execute
+
+      expect(result.filename).to eq("#{payload_service.submission_id}-answers.csv")
+      expect(result.mimetype).to eq('text/csv')
+    end
+
+    it 'adds the correct info to the attachment object' do
+      result = generate_csv_content.execute
+      file_contents = File.open(result.path).read
+      csv = CSV.new(file_contents).read
+
+      expect(csv[0]).to eq(expected_column_0)
+      expect(csv[1]).to eq(expected_column_1)
+    end
+  end
+end

--- a/spec/services/v2/submission_payload_service_spec.rb
+++ b/spec/services/v2/submission_payload_service_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.describe V2::SubmissionPayloadService do
+  subject(:payload_service) { described_class.new(payload) }
+
+  let(:submission_id) { SecureRandom.uuid }
+  let(:submission_at) { Time.zone.now.iso8601(3) }
+  let(:payload) do
+    {
+      'submission_id' => submission_id,
+      'meta' => {
+        'pdf_heading' => 'Submission for new-runner-acceptance-tests',
+        'pdf_subheading' => 'Submission subheading for new-runner-acceptance-tests',
+        'submission_at' => submission_at
+      },
+      'service' => {
+        'id' => SecureRandom.uuid,
+        'slug' => 'new-runner-acceptance-tests',
+        'name' => 'new runner acceptance tests'
+      },
+      'actions' => [
+        {
+          'kind' => 'email',
+          'to' => 'fb-acceptance-tests@digital.justice.gov.uk',
+          'from' => 'moj-forms@digital.justice.gov.uk',
+          'subject' => 'Submission from new-runner-acceptance-tests',
+          'email_body' => 'Please find attached a submission sent from new-runner-acceptance-tests',
+          'include_pdf' => true,
+          'include_attachments' => true
+        },
+        {
+          'kind' => 'csv',
+          'to' => 'fb-acceptance-tests@digital.justice.gov.uk',
+          'from' => 'moj-forms@digital.justice.gov.uk',
+          'subject' => 'Submission from new-runner-acceptance-tests',
+          'email_body' => '',
+          'include_pdf' => true,
+          'include_attachments' => false
+        }
+      ],
+      'pages' => [
+        {
+          'heading' => 'Your name',
+          'answers' => [
+            {
+              'field_id' => 'name_text_1',
+              'field_name' => 'First name',
+              'answer' => 'Stormtrooper'
+            },
+            {
+              'field_id' => 'name_text_2',
+              'field_name' => 'Last name',
+              'answer' => 'FN-b0046eb3-37ff-400d-85f8-8bbb5c11183b'
+            }
+          ]
+        },
+        {
+          'heading' => '',
+          'answers' => [
+            {
+              'field_id' => 'your-email-address_text_1',
+              'field_name' => 'Your email address',
+              'answer' => 'fb-acceptance-tests@digital.justice.gov.uk'
+            }
+          ]
+        }
+      ],
+      'attachments' => [
+        {
+          'url ' => 'http://the-filestore-url-for-attachment',
+          'filename' => 'hello_world.txt',
+          'mimetype' => 'text/plain'
+        }
+      ]
+    }
+  end
+
+  describe '#submission_id' do
+    it 'returns the correct submission id' do
+      expect(payload_service.submission_id).to eq(submission_id)
+    end
+  end
+
+  describe '#submission_at' do
+    context 'when submission_at is present' do
+      it 'returns the correctly formatted submission_at' do
+        expect(payload_service.submission_at).to eq(submission_at)
+      end
+    end
+  end
+
+  describe '#user_answers' do
+    let(:expected_user_answers) do
+      {
+        'name_text_1' => 'Stormtrooper',
+        'name_text_2' => 'FN-b0046eb3-37ff-400d-85f8-8bbb5c11183b',
+        'your-email-address_text_1' => 'fb-acceptance-tests@digital.justice.gov.uk'
+      }
+    end
+
+    it 'returns the correctly formatted user answers' do
+      expect(payload_service.user_answers).to eq(expected_user_answers)
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability for the submitter to handle CSV actions in
submissions received from V2 Runners.

We add a submission_at property to the expected schema as well since
this is used in the CSV file output.

The structure of the payload differs significantly from the legacy
Runner as the V2 Runner does not convert the data and add it all the
actions payload for the CSV. The expectation is that the Submitter will
do the conversion therefore removing the need for the users answers to
appear more than once in the payload, like the do in the legacy Runner.