### PR TITLE
Removing the version will always use the default.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker: &remote_docker
-          version: 20.10.11
           docker_layer_caching: true
       - run:
           name: test


### PR DESCRIPTION
Unpin Docker version in CircleCi config 
Removing the version will always use the default.
https://trello.com/c/LQokBApj