### PR TITLE
Use reference number in answers pdf name

### DIFF
--- a/app/services/generate_pdf_content.rb
+++ b/app/services/generate_pdf_content.rb
@@ -31,11 +31,15 @@ class GeneratePdfContent
 
   def generate_attachment_object(tmp_pdf)
     attachment = Attachment.new(
-      filename: "#{payload[:submission][:submission_id]}-answers.pdf",
+      filename: "#{submission_reference}-answers.pdf",
       mimetype: 'application/pdf'
     )
     attachment.file = tmp_pdf
     attachment
+  end
+
+  def submission_reference
+    payload[:submission][:reference_number] || payload[:submission][:submission_id]
   end
 
   attr_reader :pdf_api_gateway, :payload

--- a/app/services/pdf_payload_translator.rb
+++ b/app/services/pdf_payload_translator.rb
@@ -11,6 +11,7 @@ class PdfPayloadTranslator
     {
       submission: {
         submission_id: decrypted_submission[:submission_id],
+        reference_number: meta[:reference_number],
         pdf_heading: meta[:pdf_heading],
         pdf_subheading: meta[:pdf_subheading],
         sections: decrypted_submission[:pages].map do |page|
@@ -25,7 +26,7 @@ class PdfPayloadTranslator
             end
           }
         end
-      }
+      }.compact
     }
   end
 

--- a/spec/services/generate_pdf_content_spec.rb
+++ b/spec/services/generate_pdf_content_spec.rb
@@ -4,7 +4,8 @@ describe GeneratePdfContent do
   subject(:pdf_service) { described_class.new(pdf_api_gateway: gateway, payload: payload) }
 
   let(:gateway) { instance_spy('Adapters::PdfApi', generate_pdf: 'some pdf contents') }
-  let(:pdf_data) { { some: 'payload', submission_id: '123' } }
+  let(:submission_id) { 'some-submission-id' }
+  let(:pdf_data) { { some: 'payload', submission_id: submission_id } }
   let(:payload) { { submission: pdf_data } }
 
   context 'when requesting a pdf with a submission' do
@@ -20,9 +21,27 @@ describe GeneratePdfContent do
 
     it 'assigns the correct info the the Attachment object' do
       result = pdf_service.execute
-      expect(result.filename).to eq('123-answers.pdf')
       expect(result.mimetype).to eq('application/pdf')
       expect(File.open(result.path).read).to eq('some pdf contents')
+    end
+
+    context 'when there is no reference number present' do
+      it 'uses the submission id in the file name' do
+        result = pdf_service.execute
+        expect(result.filename).to eq("#{submission_id}-answers.pdf")
+      end
+    end
+
+    context 'when there is a reference number present' do
+      let(:reference_number) { 'some-reference-number' }
+      let(:pdf_data) do
+        { some: 'payload', submission_id: submission_id, reference_number: reference_number }
+      end
+
+      it 'uses the reference number in the file name' do
+        result = pdf_service.execute
+        expect(result.filename).to eq("#{reference_number}-answers.pdf")
+      end
     end
   end
 end

--- a/spec/services/pdf_payload_translator_spec.rb
+++ b/spec/services/pdf_payload_translator_spec.rb
@@ -6,23 +6,49 @@ RSpec.describe PdfPayloadTranslator do
   describe '#to_h' do
     context 'with a valid decrypted submission' do
       let(:submission_id) { SecureRandom.uuid }
-      let(:decrypted_submission) do
-        JSON.parse(
-          File.read(
-            Rails.root.join('spec/fixtures/payloads/valid_submission.json')
-          )
-        ).merge(submission_id: submission_id)
+      let(:valid_submission) do
+        JSON.parse(File.read(Rails.root.join('spec/fixtures/payloads/valid_submission.json')))
       end
-      let(:expected_payload) do
-        {
-          submission: JSON.parse(File.read(
-                                   Rails.root.join('spec/fixtures/payloads/pdf_generator.json')
-                                 )).merge('submission_id' => submission_id)
-        }.deep_symbolize_keys
+      let(:pdf_fixture) do
+        JSON.parse(File.read(Rails.root.join('spec/fixtures/payloads/pdf_generator.json')))
       end
 
-      it 'creates the correct pdf payload' do
-        expect(translator.to_h).to eq(expected_payload)
+      context 'when there is no reference number present' do
+        let(:decrypted_submission) do
+          valid_submission.merge(submission_id: submission_id)
+        end
+        let(:expected_payload) do
+          {
+            submission: pdf_fixture.merge('submission_id' => submission_id)
+          }.deep_symbolize_keys
+        end
+
+        it 'creates the correct pdf payload' do
+          expect(translator.to_h).to eq(expected_payload)
+        end
+      end
+
+      context 'when there is a reference number present' do
+        let(:reference_number) { 'some-reference-number' }
+        let(:decrypted_submission) do
+          sub = valid_submission.merge(submission_id: submission_id)
+          sub['meta']['reference_number'] = reference_number
+          sub
+        end
+        let(:expected_payload) do
+          {
+            submission: pdf_fixture.merge(
+              {
+                'submission_id' => submission_id,
+                'reference_number' => reference_number
+              }
+            )
+          }.deep_symbolize_keys
+        end
+
+        it 'creates the correct pdf payload' do
+          expect(translator.to_h).to eq(expected_payload)
+        end
       end
     end
   end


### PR DESCRIPTION
If there is a reference number present in the payload use that instead of the submission id to create the answers pdf file name.

Fall back to the submission ID if there is no reference number.

This only happens for the V2 endpoint, i.e the ones used by the new Runner.