### PR TITLE
Add govuk logo to emails sent via AWS SES

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby File.read('.ruby-version').strip
 
-gem 'aws-sdk-ses', '~> 1.48.0'
+gem 'aws-sdk-sesv2', '~> 1.30.0'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'daemons'
 gem 'delayed_job_active_record', '~> 4.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,13 +65,13 @@ GEM
     ansi (1.5.0)
     ast (2.4.1)
     aws-eventstream (1.2.0)
-    aws-partitions (1.660.0)
-    aws-sdk-core (3.167.0)
+    aws-partitions (1.676.0)
+    aws-sdk-core (3.168.4)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-ses (1.48.0)
+    aws-sdk-sesv2 (1.30.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.5.2)
@@ -156,7 +156,7 @@ GEM
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    jmespath (1.6.1)
+    jmespath (1.6.2)
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
@@ -345,7 +345,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk-ses (~> 1.48.0)
+  aws-sdk-sesv2 (~> 1.30.0)
   bootsnap (>= 1.1.0)
   brakeman
   byebug

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -48,7 +48,7 @@ module V2
     end
 
     def send_email(submission:, action:, attachments:, pdf_attachment: nil)
-      EmailOutputService.new(
+      EmailOutputServiceV2.new(
         emailer: EmailService,
         attachment_generator: AttachmentGenerator.new,
         encryption_service: EncryptionService.new,

--- a/app/services/adapters/amazon_ses_adapter.rb
+++ b/app/services/adapters/amazon_ses_adapter.rb
@@ -3,19 +3,21 @@ module Adapters
     # creds automatically retrieved from
     # ENV['AWS_ACCESS_KEY_ID'] and ENV['AWS_SECRET_ACCESS_KEY']
     def self.send_mail(opts = {})
-      client.send_raw_email(
-        destinations: [opts[:to]],
-        raw_message: {
-          data: opts[:raw_message].to_s
+      client.send_email(
+        from_email_address: opts[:from],
+        destination: {
+          to_addresses: [opts[:to]]
         },
-        source: opts[:from]
+        content: {
+          raw: {
+            data: opts[:raw_message].to_s
+          }
+        }
       )
     end
 
-    # eu-west-1 is the only european region to offer SES
-    # see https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
     def self.client
-      Aws::SES::Client.new(region: 'eu-west-1')
+      Aws::SESV2::Client.new(region: 'eu-west-1')
     end
   end
 end

--- a/app/services/base_email_output_service.rb
+++ b/app/services/base_email_output_service.rb
@@ -1,0 +1,86 @@
+class BaseEmailOutputService
+  include ActionView::Helpers::SanitizeHelper
+
+  def initialize(emailer:, attachment_generator:, encryption_service:, submission_id:,
+                 payload_submission_id:)
+    @emailer = emailer
+    @attachment_generator = attachment_generator
+    @encryption_service = encryption_service
+    @submission_id = submission_id
+    @payload_submission_id = payload_submission_id
+  end
+
+  def execute(action:, attachments:, pdf_attachment:)
+    attachment_generator.execute(
+      action: action,
+      attachments: attachments,
+      pdf_attachment: pdf_attachment
+    )
+
+    if attachment_generator.sorted_attachments.empty?
+      send_single_email(
+        action: action,
+        subject: subject(subject: action.fetch(:subject))
+      )
+    else
+      send_emails_with_attachments(
+        action,
+        attachment_generator.sorted_attachments
+      )
+    end
+  end
+
+  private
+
+  def send_emails_with_attachments(action, email_attachments)
+    email_attachments.each_with_index do |attachments, index|
+      send_single_email(
+        action: action,
+        attachments: attachments,
+        subject: subject(
+          subject: action.fetch(:subject),
+          current_email: index + 1,
+          number_of_emails: email_attachments.size
+        )
+      )
+    end
+  end
+
+  def send_single_email(subject:, action:, attachments: [])
+    to = action.fetch(:to)
+    email_payload = find_or_create_email_payload(to, attachments)
+
+    if email_payload.succeeded_at.nil?
+      emailer.send_mail(
+        from: action.fetch(:from),
+        to: to,
+        subject: subject,
+        body_parts: email_body_parts(action.fetch(:email_body)),
+        attachments: attachments,
+        raw_message: raw_message
+      )
+
+      email_payload.update!(succeeded_at: Time.zone.now)
+    end
+  end
+
+  def subject(subject:, current_email: 1, number_of_emails: 1)
+    "#{subject} {#{payload_submission_id}} [#{current_email}/#{number_of_emails}]"
+  end
+
+  def find_or_create_email_payload(to, attachments)
+    filenames = attachments.map(&:filename).sort
+    email_payload = EmailPayload.where(submission_id: submission_id)
+                                .find do |payload|
+                                  payload.decrypted_to == to &&
+                                    payload.decrypted_attachments == filenames
+                                end
+
+    email_payload || EmailPayload.create!(submission_id: submission_id,
+                                          to: encryption_service.encrypt(to),
+                                          attachments: encryption_service.encrypt(filenames))
+  end
+
+  attr_reader :emailer, :attachment_generator, :encryption_service, :submission_id,
+              :payload_submission_id
+end

--- a/app/services/email_output_service.rb
+++ b/app/services/email_output_service.rb
@@ -1,68 +1,6 @@
-class EmailOutputService
-  def initialize(emailer:, attachment_generator:, encryption_service:, submission_id:,
-                 payload_submission_id:)
-    @emailer = emailer
-    @attachment_generator = attachment_generator
-    @encryption_service = encryption_service
-    @submission_id = submission_id
-    @payload_submission_id = payload_submission_id
-  end
-
-  def execute(action:, attachments:, pdf_attachment:)
-    attachment_generator.execute(
-      action: action,
-      attachments: attachments,
-      pdf_attachment: pdf_attachment
-    )
-
-    if attachment_generator.sorted_attachments.empty?
-      send_single_email(
-        action: action,
-        subject: subject(subject: action.fetch(:subject))
-      )
-    else
-      send_emails_with_attachments(
-        action,
-        attachment_generator.sorted_attachments
-      )
-    end
-  end
-
-  private
-
-  def send_emails_with_attachments(action, email_attachments)
-    email_attachments.each_with_index do |attachments, index|
-      send_single_email(
-        action: action,
-        attachments: attachments,
-        subject: subject(
-          subject: action.fetch(:subject),
-          current_email: index + 1,
-          number_of_emails: email_attachments.size
-        )
-      )
-    end
-  end
-
-  def send_single_email(subject:, action:, attachments: [])
-    to = action.fetch(:to)
-    email_payload = find_or_create_email_payload(to, attachments)
-
-    if email_payload.succeeded_at.nil? # rubocop:disable Style/GuardClause
-      emailer.send_mail(
-        from: action.fetch(:from),
-        to: to,
-        subject: subject,
-        body_parts: email_body_parts(action.fetch(:email_body)),
-        attachments: attachments
-      )
-
-      email_payload.update!(succeeded_at: Time.now)
-    end
-  end
-
-  def subject(subject:, current_email: 1, number_of_emails: 1)
-    "#{subject} {#{payload_submission_id}} [#{current_email}/#{number_of_emails}]"
+class EmailOutputService < BaseEmailOutputService
+  def raw_message
+    RawMessage
   end
 
   def email_body_parts(email_body)
@@ -70,20 +8,4 @@ class EmailOutputService
       'text/plain': email_body
     }
   end
-
-  def find_or_create_email_payload(to, attachments)
-    filenames = attachments.map(&:filename).sort
-    email_payload = EmailPayload.where(submission_id: submission_id)
-                                .find do |payload|
-                                  payload.decrypted_to == to &&
-                                    payload.decrypted_attachments == filenames
-                                end
-
-    email_payload || EmailPayload.create!(submission_id: submission_id,
-                                          to: encryption_service.encrypt(to),
-                                          attachments: encryption_service.encrypt(filenames))
-  end
-
-  attr_reader :emailer, :attachment_generator, :encryption_service, :submission_id,
-              :payload_submission_id
 end

--- a/app/services/email_output_service_v2.rb
+++ b/app/services/email_output_service_v2.rb
@@ -1,0 +1,12 @@
+class EmailOutputServiceV2 < BaseEmailOutputService
+  def raw_message
+    V2::RawMessage
+  end
+
+  def email_body_parts(email_body)
+    {
+      'text/plain': strip_tags(email_body),
+      'text/html': email_body
+    }
+  end
+end

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -6,7 +6,7 @@ class EmailService
   def self.sanitised_params(opts = {})
     override_params = {}
     override_params[:to] = ENV['OVERRIDE_EMAIL_TO'] if ENV['OVERRIDE_EMAIL_TO'].present?
-    override_params[:raw_message] = RawMessage.new(opts.merge(override_params))
+    override_params[:raw_message] = opts[:raw_message].new(opts.merge(override_params))
 
     opts.merge(override_params)
   end

--- a/app/value_objects/v2/raw_message.rb
+++ b/app/value_objects/v2/raw_message.rb
@@ -1,0 +1,194 @@
+module V2
+  class RawMessage
+    attr_accessor :from, :to, :subject, :body_parts, :attachments
+
+    def initialize(opts = {})
+      symbol_params = opts.dup.symbolize_keys!
+      @attachments  = symbol_params[:attachments]
+      @body_parts   = symbol_params[:body_parts]
+      @from         = symbol_params[:from]
+      @subject      = symbol_params[:subject]
+      @to           = symbol_params[:to]
+    end
+
+    def to_s
+      <<~RAW_MESSAGE
+        From: #{@from}
+        To: #{@to}
+        Subject: #{@subject}
+        Content-Type: multipart/mixed; boundary="NextPart"
+
+        --NextPart
+        Content-Type: multipart/alternative; boundary="AltPart"
+
+        --AltPart
+        Content-Type: text/plain; charset=utf-8
+        Content-Transfer-Encoding: quoted-printable
+
+        #{[@body_parts[:'text/plain']].pack('M')}
+
+        --AltPart
+        Content-Type: text/html; charset=utf-8
+        Content-Transfer-Encoding: base64
+
+        #{Base64.encode64(body)}
+
+        --AltPart--
+
+        --NextPart
+        #{inline_attachments.join("\n\n--NextPart\n")}
+
+        --NextPart--
+      RAW_MESSAGE
+    end
+
+    private
+
+    def body
+      <<~RAW_MESSAGE
+        <html>
+          <body style="font-family: Helvetica, Arial, sans-serif;font-size: 16px;margin: 0;color:#0b0c0c;">
+
+            <!-- govuk banner -->
+            <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                    <td width="100%" height="53" bgcolor="#0b0c0c">
+                        <!--[if (gte mso 9)|(IE)]>
+                            <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 580px;">
+                            <tr>
+                            <td>
+                        <![endif]-->
+                        <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
+                            <tr>
+                                <td width="70" bgcolor="#0b0c0c" valign="middle">
+                                    <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" style="text-decoration: none;">
+                                        <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+                                            <tr>
+                                                <td style="padding-left: 10px">
+                                                    <img
+                                                        src="https://static.notifications.service.gov.uk/images/gov.uk_logotype_crown.png"
+                                                        alt=""
+                                                        height="32"
+                                                        border="0"
+                                                        style="Margin-top: 4px;"
+                                                        />
+                                                </td>
+                                                <td style="font-size: 28px; line-height: 1.315789474; Margin-top: 4px; padding-left: 10px;">
+                                                    <span style="
+                                                    font-family: Helvetica, Arial, sans-serif;
+                                                    font-weight: 700;
+                                                    color: #ffffff;
+                                                    text-decoration: none;
+                                                    vertical-align:top;
+                                                    display: inline-block;
+                                                    ">GOV.UK</span>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </a>
+                                </td>
+                            </tr>
+                        </table>
+                        <!--[if (gte mso 9)|(IE)]>
+                            </td>
+                            </tr>
+                            </table>
+                        <![endif]-->
+                    </td>
+                </tr>
+            </table>
+            <table
+                role="presentation"
+                class="content"
+                align="center"
+                cellpadding="0"
+                cellspacing="0"
+                border="0"
+                style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
+                width="100%"
+                >
+                <tr>
+                    <td width="10" height="10" valign="middle"></td>
+                    <td>
+                        <!--[if (gte mso 9)|(IE)]>
+                            <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
+                            <tr>
+                            <td height="10">
+                        <![endif]-->
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+                            <tr>
+                                <td bgcolor="#1D70B8" width="100%" height="10"></td>
+                            </tr>
+                        </table>
+                        <!--[if (gte mso 9)|(IE)]>
+                            </td>
+                            </tr>
+                            </table>
+                        <![endif]-->
+                    </td>
+                    <td width="10" valign="middle" height="10"></td>
+                </tr>
+            </table>
+            <!-- end govuk banner -->
+
+            <table
+                role="presentation"
+                class="content"
+                align="center"
+                cellpadding="0"
+                cellspacing="0"
+                border="0"
+                style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
+                width="100%"
+                >
+                <tr>
+                    <td height="30"><br /></td>
+                </tr>
+                <tr>
+                    <td width="10" valign="middle"><br /></td>
+                    <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474; max-width: 560px;">
+                        <!--[if (gte mso 9)|(IE)]>
+                            <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
+                            <tr>
+                            <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474;">
+                        <![endif]-->
+
+                        #{@body_parts[:'text/html']}
+
+                        <!--[if (gte mso 9)|(IE)]>
+                            </td>
+                            </tr>
+                            </table>
+                        <![endif]-->
+                    </td>
+                    <td width="10" valign="middle"><br /></td>
+                </tr>
+                <tr>
+                    <td height="30"><br /></td>
+                </tr>
+            </table>
+          </body>
+        </html>
+      RAW_MESSAGE
+    end
+
+    def inline_attachments
+      attachments = @attachments.map do |attachment|
+        inline_attachment(attachment)
+      end
+      Rails.logger.info("Attachments size: #{attachments.join.bytesize}")
+      attachments
+    end
+
+    def inline_attachment(attachment)
+      <<~RAW_ATTACHMENT
+        Content-Type: #{attachment.mimetype}
+        Content-Disposition: attachment; filename="#{attachment.filename_with_extension}"
+        Content-Description: #{attachment.filename_with_extension}
+        Content-Transfer-Encoding: base64
+
+        #{Base64.encode64(File.open(attachment.path, 'rb', &:read))}
+      RAW_ATTACHMENT
+    end
+  end
+end

--- a/spec/jobs/v2/process_submission_job_spec.rb
+++ b/spec/jobs/v2/process_submission_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe V2::ProcessSubmissionJob do
                    Rails.root.join('spec/fixtures/payloads/pdf_generator.json')
                  )).merge('submission_id' => submission.id)
     end
-    let(:email_output_service) { instance_spy(EmailOutputService) }
+    let(:email_output_service) { instance_spy(EmailOutputServiceV2) }
     let(:generated_pdf_content) do
       "I'm one with the Force. The Force is with me.\n"
     end
@@ -32,7 +32,7 @@ RSpec.describe V2::ProcessSubmissionJob do
     before do
       allow(ENV).to receive(:[])
       allow(ENV).to receive(:[]).with('SUBMISSION_DECRYPTION_KEY').and_return(key)
-      allow(EmailOutputService).to receive(:new).and_return(email_output_service)
+      allow(EmailOutputServiceV2).to receive(:new).and_return(email_output_service)
     end
 
     context 'when email action' do

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -5,7 +5,7 @@ describe 'UserData API', type: :request do
   describe 'a POST request' do
     let(:headers) { { 'Content-type' => 'application/json' } }
     let(:service_slug) { 'my-service' }
-    let(:stub_aws) { Aws::SES::Client.new(region: 'eu-west-1', stub_responses: true) }
+    let(:stub_aws) { Aws::SESV2::Client.new(region: 'eu-west-1', stub_responses: true) }
     let(:pdf_file_content) { 'pdf binary goes here' }
     let(:url) { '/submission' }
     let(:post_request) { post url, params: params.to_json, headers: headers }
@@ -17,7 +17,7 @@ describe 'UserData API', type: :request do
       stub_request(:get, 'http://fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/ioj/user/a239313d-4d2d-4a16-b5ef-69d6e8e53e86/28d-aaa59621acecd4b1596dd0e96968c6cec3fae7927613a12c357e7a62e1187aaa').to_return(status: 200, body: '', headers: {})
       stub_request(:get, 'http://fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/ioj/user/a239313d-4d2d-4a16-b5ef-69d6e8e53e86/28d-dae59621acecd4b1596dd0e96968c6cec3fae7927613a12c357e7a62e11877d8').to_return(status: 200, body: '', headers: {})
 
-      allow(Aws::SES::Client).to receive(:new).with(region: 'eu-west-1').and_return(stub_aws)
+      allow(Aws::SESV2::Client).to receive(:new).with(region: 'eu-west-1').and_return(stub_aws)
 
       # PDF Generator stubs
       stub_request(:get, 'http://fake_service_token_cache_root_url/service/my-service').to_return(status: 200, body: { token: '123' }.to_json)
@@ -128,7 +128,7 @@ describe 'UserData API', type: :request do
         context 'when the request is successful' do
           let(:raw_messages) do
             stub_aws.api_requests.map do |request|
-              request[:params][:raw_message][:data]
+              request[:params][:content][:raw][:data]
             end
           end
 

--- a/spec/services/adapters/amazon_ses_adapter_spec.rb
+++ b/spec/services/adapters/amazon_ses_adapter_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 describe Adapters::AmazonSESAdapter do
   before do
-    allow(Aws::SES::Client).to receive(:new).with(region: 'eu-west-1').and_return(stub_aws)
+    allow(Aws::SESV2::Client).to receive(:new).with(region: 'eu-west-1').and_return(stub_aws)
   end
 
   let(:stub_aws) do
-    Aws::SES::Client.new(region: 'eu-west-1', stub_responses: true)
+    Aws::SESV2::Client.new(region: 'eu-west-1', stub_responses: true)
   end
 
   it 'returns the response given the correct params' do
-    expect(described_class.send_mail(to: '', raw_message: '', from: '').to_h).to eq(message_id: 'MessageId')
+    expect(described_class.send_mail(to: '', raw_message: '', from: '').to_h).to eq(message_id: 'OutboundMessageId')
   end
 end

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -18,7 +18,7 @@ describe EmailService do
   end
 
   describe '.sanitised_params' do
-    let(:opts) { { key: 'value', to: 'to@example.com' } }
+    let(:opts) { { key: 'value', to: 'to@example.com', raw_message: V2::RawMessage } }
 
     describe 'return value' do
       let(:return_value) { described_class.sanitised_params(opts) }
@@ -68,7 +68,7 @@ describe EmailService do
   end
 
   describe '.send_mail' do
-    let(:opts) { { key: 'value', to: 'to@example.com' } }
+    let(:opts) { { key: 'value', to: 'to@example.com', raw_message: V2::RawMessage } }
     let(:sanitised_params) { { key: 'sanitised value' } }
 
     before do

--- a/spec/value_objects/v2/raw_message_spec.rb
+++ b/spec/value_objects/v2/raw_message_spec.rb
@@ -1,0 +1,217 @@
+require 'rails_helper'
+
+RSpec.describe V2::RawMessage do
+  subject(:raw_message) do
+    described_class.new(
+      from: 'sender@example.com',
+      to: 'reciver@example.com',
+      subject: 'test email',
+      body_parts: {
+        'text/plain': 'some body',
+        'text/html': 'some body'
+      },
+      attachments: [attachment]
+    )
+  end
+
+  before do
+    allow(File).to receive(:read).and_return('hello world')
+  end
+
+  let(:attachment) do
+    build(
+      :attachment,
+      filename: 'some-file-name.jpg',
+      mimetype: 'application/pdf',
+      path: file_fixture('hello_world.txt')
+    )
+  end
+  let(:body) do
+    <<~RAW_MESSAGE
+      <html>
+        <body style="font-family: Helvetica, Arial, sans-serif;font-size: 16px;margin: 0;color:#0b0c0c;">
+
+          <!-- govuk banner -->
+          <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
+              <tr>
+                  <td width="100%" height="53" bgcolor="#0b0c0c">
+                      <!--[if (gte mso 9)|(IE)]>
+                          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 580px;">
+                          <tr>
+                          <td>
+                      <![endif]-->
+                      <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
+                          <tr>
+                              <td width="70" bgcolor="#0b0c0c" valign="middle">
+                                  <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" style="text-decoration: none;">
+                                      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+                                          <tr>
+                                              <td style="padding-left: 10px">
+                                                  <img
+                                                      src="https://static.notifications.service.gov.uk/images/gov.uk_logotype_crown.png"
+                                                      alt=""
+                                                      height="32"
+                                                      border="0"
+                                                      style="Margin-top: 4px;"
+                                                      />
+                                              </td>
+                                              <td style="font-size: 28px; line-height: 1.315789474; Margin-top: 4px; padding-left: 10px;">
+                                                  <span style="
+                                                  font-family: Helvetica, Arial, sans-serif;
+                                                  font-weight: 700;
+                                                  color: #ffffff;
+                                                  text-decoration: none;
+                                                  vertical-align:top;
+                                                  display: inline-block;
+                                                  ">GOV.UK</span>
+                                              </td>
+                                          </tr>
+                                      </table>
+                                  </a>
+                              </td>
+                          </tr>
+                      </table>
+                      <!--[if (gte mso 9)|(IE)]>
+                          </td>
+                          </tr>
+                          </table>
+                      <![endif]-->
+                  </td>
+              </tr>
+          </table>
+          <table
+              role="presentation"
+              class="content"
+              align="center"
+              cellpadding="0"
+              cellspacing="0"
+              border="0"
+              style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
+              width="100%"
+              >
+              <tr>
+                  <td width="10" height="10" valign="middle"></td>
+                  <td>
+                      <!--[if (gte mso 9)|(IE)]>
+                          <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
+                          <tr>
+                          <td height="10">
+                      <![endif]-->
+                      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+                          <tr>
+                              <td bgcolor="#1D70B8" width="100%" height="10"></td>
+                          </tr>
+                      </table>
+                      <!--[if (gte mso 9)|(IE)]>
+                          </td>
+                          </tr>
+                          </table>
+                      <![endif]-->
+                  </td>
+                  <td width="10" valign="middle" height="10"></td>
+              </tr>
+          </table>
+          <!-- end govuk banner -->
+
+          <table
+              role="presentation"
+              class="content"
+              align="center"
+              cellpadding="0"
+              cellspacing="0"
+              border="0"
+              style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
+              width="100%"
+              >
+              <tr>
+                  <td height="30"><br /></td>
+              </tr>
+              <tr>
+                  <td width="10" valign="middle"><br /></td>
+                  <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474; max-width: 560px;">
+                      <!--[if (gte mso 9)|(IE)]>
+                          <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
+                          <tr>
+                          <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474;">
+                      <![endif]-->
+
+                      #{raw_message.body_parts[:'text/html']}
+
+                      <!--[if (gte mso 9)|(IE)]>
+                          </td>
+                          </tr>
+                          </table>
+                      <![endif]-->
+                  </td>
+                  <td width="10" valign="middle"><br /></td>
+              </tr>
+              <tr>
+                  <td height="30"><br /></td>
+              </tr>
+          </table>
+        </body>
+      </html>
+    RAW_MESSAGE
+  end
+  let(:expected_email) do
+    <<~RAW_MESSAGE
+      From: sender@example.com
+      To: reciver@example.com
+      Subject: test email
+      Content-Type: multipart/mixed; boundary="NextPart"
+
+      --NextPart
+      Content-Type: multipart/alternative; boundary="AltPart"
+
+      --AltPart
+      Content-Type: text/plain; charset=utf-8
+      Content-Transfer-Encoding: quoted-printable
+
+      some body=
+
+
+      --AltPart
+      Content-Type: text/html; charset=utf-8
+      Content-Transfer-Encoding: base64
+
+      #{Base64.encode64(body)}
+
+      --AltPart--
+
+      --NextPart
+      Content-Type: application/pdf
+      Content-Disposition: attachment; filename="some-file-name.pdf"
+      Content-Description: some-file-name.pdf
+      Content-Transfer-Encoding: base64
+
+      aGVsbG8gd29ybGQK
+
+
+
+      --NextPart--
+    RAW_MESSAGE
+  end
+
+  it 'uses correct filename and extension' do
+    expect(raw_message.to_s).to include('some-file-name.pdf')
+  end
+
+  it 'creates the expected raw message' do
+    expect(raw_message.to_s).to eq(expected_email)
+  end
+
+  context 'when filename does not have extension' do
+    let(:attachment) do
+      build(
+        :attachment,
+        filename: 'some-file-name',
+        mimetype: 'application/pdf',
+        path: file_fixture('hello_world.txt')
+      )
+    end
+
+    it 'uses correct extension for given mimetype' do
+      expect(raw_message.to_s).to include('some-file-name.pdf')
+    end
+  end
+end


### PR DESCRIPTION
This adds the banner to emails sent from the Submitter for all V2
endpoint submissions, that is the new runner. Legacy runner submissions
will remain unchanged.

The version 1 code should be removed once all legacy forms have been
migrated.

![Screenshot 2022-12-15 at 15 21 37](https://user-images.githubusercontent.com/3466862/207898914-d1d58141-063a-49a1-b5ca-fd8c0a65b216.png)

