### PR TITLE
Use MoJ Forms default no reply email as from address

### DIFF
--- a/app/services/adapters/amazon_ses_adapter.rb
+++ b/app/services/adapters/amazon_ses_adapter.rb
@@ -1,13 +1,16 @@
 module Adapters
   class AmazonSESAdapter
+    DEFAULT_FROM_ADDRESS = 'no-reply-moj-forms@digital.justice.gov.uk'.freeze
+
     # creds automatically retrieved from
     # ENV['AWS_ACCESS_KEY_ID'] and ENV['AWS_SECRET_ACCESS_KEY']
     def self.send_mail(opts = {})
       client.send_email(
-        from_email_address: opts[:from],
+        from_email_address: DEFAULT_FROM_ADDRESS,
         destination: {
           to_addresses: [opts[:to]]
         },
+        reply_to_addresses: ([opts[:from]] - [DEFAULT_FROM_ADDRESS]).compact,
         content: {
           raw: {
             data: opts[:raw_message].to_s

--- a/spec/services/adapters/amazon_ses_adapter_spec.rb
+++ b/spec/services/adapters/amazon_ses_adapter_spec.rb
@@ -12,4 +12,62 @@ describe Adapters::AmazonSESAdapter do
   it 'returns the response given the correct params' do
     expect(described_class.send_mail(to: '', raw_message: '', from: '').to_h).to eq(message_id: 'OutboundMessageId')
   end
+
+  context 'when sending email payload' do
+    let(:to_address) { 'someaddress' }
+    let(:from_address) { 'someaddress' }
+    let(:email_body) { 'email body' }
+    let(:opts) do
+      {
+        to: to_address,
+        from: from_address,
+        raw_message: double(to_s: email_body) # rubocop:disable RSpec/VerifiedDoubles
+      }
+    end
+    let(:expected_payload) do
+      {
+        from_email_address: Adapters::AmazonSESAdapter::DEFAULT_FROM_ADDRESS,
+        destination: {
+          to_addresses: [to_address]
+        },
+        reply_to_addresses: expected_reply_to_addresses,
+        content: {
+          raw: {
+            data: email_body
+          }
+        }
+      }
+    end
+
+    # rubocop:disable RSpec/MessageSpies
+    context 'when from address is different to moj forms default address' do
+      let(:expected_reply_to_addresses) { [from_address] }
+
+      it 'uses the supplied from address as the reply to address' do
+        expect(stub_aws).to receive(:send_email).with(expected_payload)
+        described_class.send_mail(opts)
+      end
+    end
+
+    context 'when from address is the same as moj forms default address' do
+      let(:from_address) { Adapters::AmazonSESAdapter::DEFAULT_FROM_ADDRESS }
+      let(:expected_reply_to_addresses) { [] }
+
+      it 'does not set a reply to address' do
+        expect(stub_aws).to receive(:send_email).with(expected_payload)
+        described_class.send_mail(opts)
+      end
+    end
+
+    context 'when the from address is not present' do
+      let(:from_address) { nil }
+      let(:expected_reply_to_addresses) { [] }
+
+      it 'does not set a reply to address' do
+        expect(stub_aws).to receive(:send_email).with(expected_payload)
+        described_class.send_mail(opts)
+      end
+    end
+    # rubocop:enable RSpec/MessageSpies
+  end
 end


### PR DESCRIPTION
This is because we have been getting reports of undelivered messages when sent to certain email clients when using certain From Addresses that have been set by the user.

Until a more long term fix is found use the MoJ Forms default no reply address and set the Editor user's From Address as the Reply to address.

If the from address is the same as the MoJ Forms default no reply address then do not set a reply to address in the payload sent to AWS.