### PR TITLE
Brakeman ignore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - ruby/install-deps
       - run:
           name: security
-          command: bundle exec brakeman -q --no-pager
+          command: bundle exec brakeman -q --no-pager -i brakeman.ignore
       - slack/status: *slack_status
   build_and_push_image:
     working_directory: ~/circle/git/fb-submitter

--- a/brakeman.ignore
+++ b/brakeman.ignore
@@ -1,0 +1,25 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 123,
+      "fingerprint": "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 2.7.7 ends on 2023-03-31",
+      "file": "Gemfile.lock",
+      "line": 208,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": "We have prioritised upgrading to Ruby 3. In the meantime, ignore so we unblock the pipeline."
+    }
+  ],
+  "updated": "2023-01-30 13:45:58 +0000",
+  "brakeman_version": "5.4.0"
+}


### PR DESCRIPTION
We have a EOLRuby warning that is preventing us from deploying the app to production.
This warning tells us to upgrade the app to Ruby 3.

We have now prioritised this work, so for the time being ignore this warning.
Ignoring this warning will allow us to continue deploying the app to production.