### PR TITLE
Remove submission id

### DIFF
--- a/app/services/base_email_output_service.rb
+++ b/app/services/base_email_output_service.rb
@@ -65,7 +65,7 @@ class BaseEmailOutputService
   end
 
   def subject(subject:, current_email: 1, number_of_emails: 1)
-    "#{subject} {#{payload_submission_id}} [#{current_email}/#{number_of_emails}]"
+    "#{subject} [#{current_email}/#{number_of_emails}]"
   end
 
   def find_or_create_email_payload(to, attachments)

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -69,7 +69,7 @@ describe EmailOutputService do
     {
       to: 'bob.admin@digital.justice.gov.uk',
       from: 'form-builder@digital.justice.gov.uk',
-      subject: 'Complain about a court or tribunal submission {an-id-2323} [1/1]',
+      subject: 'Complain about a court or tribunal submission [1/1]',
       body_parts: {
         'text/plain': 'Please find an application attached'
       },
@@ -107,8 +107,8 @@ describe EmailOutputService do
       end
 
       it 'the subject is numbered by how many separate emails there are' do
-        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]')).once
-        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]')).once
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission [1/2]')).once
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission [2/2]')).once
       end
 
       it 'creates the required email payload records' do
@@ -130,7 +130,7 @@ describe EmailOutputService do
       end
 
       it 'the subject is numbered [1/1] as there will be a single email' do
-        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [1/1]')).once
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission [1/1]')).once
       end
     end
 
@@ -156,13 +156,13 @@ describe EmailOutputService do
     let(:second_email_attachments) { [upload3] }
     let(:first_payload) do
       send_email_payload.merge(
-        subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]',
+        subject: 'Complain about a court or tribunal submission [1/2]',
         attachments: first_email_attachments
       )
     end
     let(:second_payload) do
       send_email_payload.merge(
-        subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]',
+        subject: 'Complain about a court or tribunal submission [2/2]',
         attachments: second_email_attachments
       )
     end
@@ -250,8 +250,8 @@ describe EmailOutputService do
         expect(email_service_mock).to have_received(:send_mail).exactly(4).times
         expect(email_service_mock).to have_received(:send_mail).with(hash_including(to: 'bob.admin@digital.justice.gov.uk')).twice
         expect(email_service_mock).to have_received(:send_mail).with(hash_including(to: 'robert.admin@digital.justice.gov.uk')).twice
-        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]')).twice
-        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]')).twice
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission [1/2]')).twice
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission [2/2]')).twice
       end
 
       it 'will creates email payloads to the necessary recipients with the correct attachments' do
@@ -285,27 +285,27 @@ describe EmailOutputService do
       end
       let(:first_payload) do
         send_email_payload.merge(
-          subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]',
+          subject: 'Complain about a court or tribunal submission [1/2]',
           attachments: first_email_attachments
         )
       end
       let(:second_payload) do
         send_email_payload.merge(
-          subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]',
+          subject: 'Complain about a court or tribunal submission [2/2]',
           attachments: second_email_attachments
         )
       end
       let(:third_payload) do
         send_email_payload.merge(
           to: 'robert.admin@digital.justice.gov.uk',
-          subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]',
+          subject: 'Complain about a court or tribunal submission [1/2]',
           attachments: first_email_attachments
         )
       end
       let(:fourth_payload) do
         send_email_payload.merge(
           to: 'robert.admin@digital.justice.gov.uk',
-          subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]',
+          subject: 'Complain about a court or tribunal submission [2/2]',
           attachments: second_email_attachments
         )
       end

--- a/spec/services/email_output_service_v2_spec.rb
+++ b/spec/services/email_output_service_v2_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe EmailOutputServiceV2 do
     {
       to: 'bob.admin@digital.justice.gov.uk',
       from: 'form-builder@digital.justice.gov.uk',
-      subject: 'Complain about a court or tribunal submission {an-id-2323} [1/1]',
+      subject: 'Complain about a court or tribunal submission [1/1]',
       body_parts: {
         'text/plain': 'Please find an application attached',
         'text/html': 'Please find an application attached'
@@ -108,8 +108,8 @@ RSpec.describe EmailOutputServiceV2 do
       end
 
       it 'the subject is numbered by how many separate emails there are' do
-        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]')).once
-        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]')).once
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission [1/2]')).once
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission [2/2]')).once
       end
 
       it 'creates the required email payload records' do
@@ -131,7 +131,7 @@ RSpec.describe EmailOutputServiceV2 do
       end
 
       it 'the subject is numbered [1/1] as there will be a single email' do
-        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [1/1]')).once
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission [1/1]')).once
       end
     end
 
@@ -157,13 +157,13 @@ RSpec.describe EmailOutputServiceV2 do
     let(:second_email_attachments) { [upload3] }
     let(:first_payload) do
       send_email_payload.merge(
-        subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]',
+        subject: 'Complain about a court or tribunal submission [1/2]',
         attachments: first_email_attachments
       )
     end
     let(:second_payload) do
       send_email_payload.merge(
-        subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]',
+        subject: 'Complain about a court or tribunal submission [2/2]',
         attachments: second_email_attachments
       )
     end
@@ -251,8 +251,8 @@ RSpec.describe EmailOutputServiceV2 do
         expect(email_service_mock).to have_received(:send_mail).exactly(4).times
         expect(email_service_mock).to have_received(:send_mail).with(hash_including(to: 'bob.admin@digital.justice.gov.uk')).twice
         expect(email_service_mock).to have_received(:send_mail).with(hash_including(to: 'robert.admin@digital.justice.gov.uk')).twice
-        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]')).twice
-        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]')).twice
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission [1/2]')).twice
+        expect(email_service_mock).to have_received(:send_mail).with(hash_including(subject: 'Complain about a court or tribunal submission [2/2]')).twice
       end
 
       it 'will creates email payloads to the necessary recipients with the correct attachments' do
@@ -286,27 +286,27 @@ RSpec.describe EmailOutputServiceV2 do
       end
       let(:first_payload) do
         send_email_payload.merge(
-          subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]',
+          subject: 'Complain about a court or tribunal submission [1/2]',
           attachments: first_email_attachments
         )
       end
       let(:second_payload) do
         send_email_payload.merge(
-          subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]',
+          subject: 'Complain about a court or tribunal submission [2/2]',
           attachments: second_email_attachments
         )
       end
       let(:third_payload) do
         send_email_payload.merge(
           to: 'robert.admin@digital.justice.gov.uk',
-          subject: 'Complain about a court or tribunal submission {an-id-2323} [1/2]',
+          subject: 'Complain about a court or tribunal submission [1/2]',
           attachments: first_email_attachments
         )
       end
       let(:fourth_payload) do
         send_email_payload.merge(
           to: 'robert.admin@digital.justice.gov.uk',
-          subject: 'Complain about a court or tribunal submission {an-id-2323} [2/2]',
+          subject: 'Complain about a court or tribunal submission [2/2]',
           attachments: second_email_attachments
         )
       end


### PR DESCRIPTION
## Scope

We have both submission id and reference number in confirmation and submission emails. This is confusing for the end user because they don't use a submission id. We still require submission id internally but we don't need to send it in the subject of emails. We remove submission ID from subject of base emails. This will work for both confirmation and submission emails. 

## Testing 
It has been tested manually :

For the form with the reference number: 
<img width="828" alt="Screenshot 2023-02-01 at 11 01 46" src="https://user-images.githubusercontent.com/26165112/216026755-8b94208e-b686-4fdb-8a55-5176add16a90.png">

The confirmation and submission emails have been received:
<img width="924" alt="Screenshot 2023-02-01 at 11 02 06" src="https://user-images.githubusercontent.com/26165112/216026822-c94897a2-1d68-43bc-88e5-7241b7602932.png">

Tests have been updated accordingly






