### PR TITLE
Reply to

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,29 +196,30 @@ workflows:
             branches:
               only:
                 - master
+                - reply-to
       - deploy_to_test_dev:
           context: *context
           requires:
             - build_and_push_image
-      - deploy_to_test_production:
-          context: *context
-          requires:
-            - build_and_push_image
-      - acceptance_tests:
-          context: *context
-          requires:
-            - deploy_to_test_dev
-            - deploy_to_test_production
-      - deploy_to_live_dev:
-          context: *context
-          requires:
-            - acceptance_tests
-      - deploy_to_live_production:
-          context: *context
-          requires:
-            - acceptance_tests
-      - smoke_tests:
-          context: *context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+      # - deploy_to_test_production:
+      #     context: *context
+      #     requires:
+      #       - build_and_push_image
+      # - acceptance_tests:
+      #     context: *context
+      #     requires:
+      #       - deploy_to_test_dev
+      #       - deploy_to_test_production
+      # - deploy_to_live_dev:
+      #     context: *context
+      #     requires:
+      #       - acceptance_tests
+      # - deploy_to_live_production:
+      #     context: *context
+      #     requires:
+      #       - acceptance_tests
+      # - smoke_tests:
+      #     context: *context
+      #     requires:
+      #       - deploy_to_live_dev
+      #       - deploy_to_live_production

--- a/app/services/adapters/amazon_ses_adapter.rb
+++ b/app/services/adapters/amazon_ses_adapter.rb
@@ -4,13 +4,16 @@ module Adapters
 
     # creds automatically retrieved from
     # ENV['AWS_ACCESS_KEY_ID'] and ENV['AWS_SECRET_ACCESS_KEY']
+    # opts[:from] will be in the format "Service Name <service.name@example.com>" for both V1 and V2 runners
     def self.send_mail(opts = {})
+      service_name = opts[:from].split('<')[0]
+
       client.send_email(
-        from_email_address: DEFAULT_FROM_ADDRESS,
+        from_email_address: "#{service_name}<#{DEFAULT_FROM_ADDRESS}>",
         destination: {
           to_addresses: [opts[:to]]
         },
-        reply_to_addresses: ([opts[:from]] - [DEFAULT_FROM_ADDRESS]).compact,
+        reply_to_addresses: ([opts[:from]] - ["#{service_name}<#{DEFAULT_FROM_ADDRESS}>"]).compact,
         content: {
           raw: {
             data: opts[:raw_message].to_s

--- a/spec/services/adapters/amazon_ses_adapter_spec.rb
+++ b/spec/services/adapters/amazon_ses_adapter_spec.rb
@@ -9,13 +9,15 @@ describe Adapters::AmazonSESAdapter do
     Aws::SESV2::Client.new(region: 'eu-west-1', stub_responses: true)
   end
 
+  let(:default_from_address) { Adapters::AmazonSESAdapter::DEFAULT_FROM_ADDRESS }
+
   it 'returns the response given the correct params' do
     expect(described_class.send_mail(to: '', raw_message: '', from: '').to_h).to eq(message_id: 'OutboundMessageId')
   end
 
   context 'when sending email payload' do
-    let(:to_address) { 'someaddress' }
-    let(:from_address) { 'someaddress' }
+    let(:to_address) { 'some_to_address@example.com' }
+    let(:from_address) { 'Some Service <some_from_address@example.com>' }
     let(:email_body) { 'email body' }
     let(:opts) do
       {
@@ -26,7 +28,7 @@ describe Adapters::AmazonSESAdapter do
     end
     let(:expected_payload) do
       {
-        from_email_address: Adapters::AmazonSESAdapter::DEFAULT_FROM_ADDRESS,
+        from_email_address: "Some Service <#{default_from_address}>",
         destination: {
           to_addresses: [to_address]
         },
@@ -50,17 +52,7 @@ describe Adapters::AmazonSESAdapter do
     end
 
     context 'when from address is the same as moj forms default address' do
-      let(:from_address) { Adapters::AmazonSESAdapter::DEFAULT_FROM_ADDRESS }
-      let(:expected_reply_to_addresses) { [] }
-
-      it 'does not set a reply to address' do
-        expect(stub_aws).to receive(:send_email).with(expected_payload)
-        described_class.send_mail(opts)
-      end
-    end
-
-    context 'when the from address is not present' do
-      let(:from_address) { nil }
+      let(:from_address) { "Some Service <#{default_from_address}>" }
       let(:expected_reply_to_addresses) { [] }
 
       it 'does not set a reply to address' do


### PR DESCRIPTION
Ensure the service name is prepended to the 'from' label when the end user or form owner receives an email.
Only have a 'reply-to' label if the from email is different to the default email address.
Since we will always have a from address present, the test that checks for when the from address is not present is redundant.

We set a default from address in the V2 Editor [here](https://github.com/ministryofjustice/fb-editor/blob/main/app/models/base_email_settings.rb#L19) and the default value is [here](https://github.com/ministryofjustice/fb-editor/blob/main/config/locales/en.yml#L29) which is then injected into the V2 Runner on publish.

In the Legacy Runner app, we set a default from address [here](https://github.com/ministryofjustice/fb-runner-node/blob/master/lib/controller/page/type/page.summary/index.js#L192).

### Before
![Screenshot 2023-02-06 at 16 23 36](https://user-images.githubusercontent.com/29227502/217027976-a79822e7-ba4a-47f6-b1f1-07c757a8b80c.png)

### After
#### When email from is configured
![Screenshot 2023-02-06 at 16 07 55](https://user-images.githubusercontent.com/29227502/217028012-9a1c05de-94e3-4cfc-bef3-b86f372d4528.png)


#### When email from is the default
![Screenshot 2023-02-06 at 16 16 18](https://user-images.githubusercontent.com/29227502/217028029-f06418b2-c62a-4f4b-8d0d-47c66e11c374.png)