### PR TITLE
Reply-To: Use the correct values for from and reply-to

### DIFF
--- a/app/services/adapters/amazon_ses_adapter.rb
+++ b/app/services/adapters/amazon_ses_adapter.rb
@@ -4,13 +4,16 @@ module Adapters
 
     # creds automatically retrieved from
     # ENV['AWS_ACCESS_KEY_ID'] and ENV['AWS_SECRET_ACCESS_KEY']
+    # opts[:from] will be in the format "Service Name <service.name@example.com>" for both V1 and V2 runners
     def self.send_mail(opts = {})
+      service_name = opts[:from].split('<')[0]
+
       client.send_email(
-        from_email_address: DEFAULT_FROM_ADDRESS,
+        from_email_address: opts[:from],
         destination: {
           to_addresses: [opts[:to]]
         },
-        reply_to_addresses: ([opts[:from]] - [DEFAULT_FROM_ADDRESS]).compact,
+        reply_to_addresses: ([opts[:from]] - ["#{service_name}<#{DEFAULT_FROM_ADDRESS}>"]).compact,
         content: {
           raw: {
             data: opts[:raw_message].to_s

--- a/app/services/adapters/amazon_ses_adapter.rb
+++ b/app/services/adapters/amazon_ses_adapter.rb
@@ -9,7 +9,7 @@ module Adapters
       service_name = opts[:from].split('<')[0]
 
       client.send_email(
-        from_email_address: opts[:from],
+        from_email_address: "#{service_name}<#{DEFAULT_FROM_ADDRESS}>",
         destination: {
           to_addresses: [opts[:to]]
         },

--- a/spec/services/adapters/amazon_ses_adapter_spec.rb
+++ b/spec/services/adapters/amazon_ses_adapter_spec.rb
@@ -8,25 +8,27 @@ describe Adapters::AmazonSESAdapter do
   let(:stub_aws) do
     Aws::SESV2::Client.new(region: 'eu-west-1', stub_responses: true)
   end
+  let(:default_from_address) { Adapters::AmazonSESAdapter::DEFAULT_FROM_ADDRESS }
 
   it 'returns the response given the correct params' do
     expect(described_class.send_mail(to: '', raw_message: '', from: '').to_h).to eq(message_id: 'OutboundMessageId')
   end
 
   context 'when sending email payload' do
-    let(:to_address) { 'someaddress' }
-    let(:from_address) { 'someaddress' }
+    let(:to_address) { 'some_to_address@example.com' }
+    let(:supplied_from_address) { 'Some Service <some_from_address@example.com>' }
     let(:email_body) { 'email body' }
+    let(:expected_from_email_address) { "Some Service <#{default_from_address}>" }
     let(:opts) do
       {
         to: to_address,
-        from: from_address,
+        from: supplied_from_address,
         raw_message: double(to_s: email_body) # rubocop:disable RSpec/VerifiedDoubles
       }
     end
     let(:expected_payload) do
       {
-        from_email_address: Adapters::AmazonSESAdapter::DEFAULT_FROM_ADDRESS,
+        from_email_address: expected_from_email_address,
         destination: {
           to_addresses: [to_address]
         },
@@ -40,8 +42,9 @@ describe Adapters::AmazonSESAdapter do
     end
 
     # rubocop:disable RSpec/MessageSpies
-    context 'when from address is different to moj forms default address' do
-      let(:expected_reply_to_addresses) { [from_address] }
+    context 'when the supplied from address is different to moj forms default address' do
+      let(:expected_reply_to_addresses) { [supplied_from_address] }
+      let(:expected_from_email_address) { supplied_from_address }
 
       it 'uses the supplied from address as the reply to address' do
         expect(stub_aws).to receive(:send_email).with(expected_payload)
@@ -50,7 +53,7 @@ describe Adapters::AmazonSESAdapter do
     end
 
     context 'when from address is the same as moj forms default address' do
-      let(:from_address) { Adapters::AmazonSESAdapter::DEFAULT_FROM_ADDRESS }
+      let(:supplied_from_address) { "Some Service <#{default_from_address}>" }
       let(:expected_reply_to_addresses) { [] }
 
       it 'does not set a reply to address' do
@@ -59,11 +62,11 @@ describe Adapters::AmazonSESAdapter do
       end
     end
 
-    context 'when the from address is not present' do
-      let(:from_address) { nil }
-      let(:expected_reply_to_addresses) { [] }
+    context 'when from address and reply to have been configured' do
+      let(:expected_reply_to_addresses) { [supplied_from_address] }
+      let(:expected_from_email_address) { supplied_from_address }
 
-      it 'does not set a reply to address' do
+      it 'uses the supplied from email address as the from and reply to address' do
         expect(stub_aws).to receive(:send_email).with(expected_payload)
         described_class.send_mail(opts)
       end

--- a/spec/services/adapters/amazon_ses_adapter_spec.rb
+++ b/spec/services/adapters/amazon_ses_adapter_spec.rb
@@ -9,6 +9,7 @@ describe Adapters::AmazonSESAdapter do
     Aws::SESV2::Client.new(region: 'eu-west-1', stub_responses: true)
   end
   let(:default_from_address) { Adapters::AmazonSESAdapter::DEFAULT_FROM_ADDRESS }
+  let(:expected_from_email_address) { "Some Service <#{default_from_address}>" }
 
   it 'returns the response given the correct params' do
     expect(described_class.send_mail(to: '', raw_message: '', from: '').to_h).to eq(message_id: 'OutboundMessageId')
@@ -18,7 +19,6 @@ describe Adapters::AmazonSESAdapter do
     let(:to_address) { 'some_to_address@example.com' }
     let(:supplied_from_address) { 'Some Service <some_from_address@example.com>' }
     let(:email_body) { 'email body' }
-    let(:expected_from_email_address) { "Some Service <#{default_from_address}>" }
     let(:opts) do
       {
         to: to_address,
@@ -44,7 +44,6 @@ describe Adapters::AmazonSESAdapter do
     # rubocop:disable RSpec/MessageSpies
     context 'when the supplied from address is different to moj forms default address' do
       let(:expected_reply_to_addresses) { [supplied_from_address] }
-      let(:expected_from_email_address) { supplied_from_address }
 
       it 'uses the supplied from address as the reply to address' do
         expect(stub_aws).to receive(:send_email).with(expected_payload)
@@ -64,7 +63,6 @@ describe Adapters::AmazonSESAdapter do
 
     context 'when from address and reply to have been configured' do
       let(:expected_reply_to_addresses) { [supplied_from_address] }
-      let(:expected_from_email_address) { supplied_from_address }
 
       it 'uses the supplied from email address as the from and reply to address' do
         expect(stub_aws).to receive(:send_email).with(expected_payload)


### PR DESCRIPTION
The Runner will now pass the Submitter the service name with the email address, ie: `"Service Name <service.name@example.com>"`.
For a service email, the from address will be the default no-reply MoJ email address.
For a confirmation email, the supplied from address will be the reply-to email. Therefore, we need to use the default moj no reply address as the from and only use the supplied `opts[:from]`value if it is different to the moj no reply address.

We also only want to use the reply-to field if the `opts[:from]` is not the default moj email address.