### PR TITLE
Use update Github RSA SSH key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,7 @@ jobs:
     docker: *ecr_image
     resource_class: large
     steps:
+      - checkout
       - setup_remote_docker: *remote_docker
       - run: *deploy_scripts
       - run:
@@ -165,6 +166,7 @@ jobs:
   smoke_tests:
     docker: *ecr_image
     steps:
+      - checkout
       - setup_remote_docker: *remote_docker
       - run: *deploy_scripts
       - run:


### PR DESCRIPTION
### Add 'checkout' step to CircleCI config
Github have recently rotated their RSA SSH host key. As a result, the public key is no longer up to date in the known_host file.

The 'checkout' step automatically adds the required authenticity keys for interacting with Github. Adding this job allows the acceptance test and smoke tests steps to interact with Github.

CircleCI run:
https://app.circleci.com/pipelines/github/ministryofjustice/fb-submitter/3250/workflows/55d6fd88-aebc-4d9e-85eb-a3b1e63a18b0
