### PR TITLE
Bug attachment full stops

### DIFF
--- a/app/value_objects/attachment.rb
+++ b/app/value_objects/attachment.rb
@@ -15,8 +15,8 @@ class Attachment
   end
 
   def filename_with_extension
-    head, *tail = filename.split('.').reverse
-    raw_filename = tail.reverse.join.presence || head
+    head, *tail = filename.rpartition('.').reverse
+    raw_filename = tail.last.presence || head
     ext = MIME::Types[@mimetype][0].preferred_extension
 
     "#{raw_filename}.#{ext}"

--- a/spec/value_objects/raw_message_spec.rb
+++ b/spec/value_objects/raw_message_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe RawMessage do
   let(:attachment) do
     build(
       :attachment,
-      filename: 'some-file-name.jpg',
-      mimetype: 'application/pdf',
+      filename:,
+      mimetype:,
       path: file_fixture('hello_world.txt')
     )
   end
@@ -46,7 +46,7 @@ RSpec.describe RawMessage do
 
       --NextPart
       Content-Type: application/pdf
-      Content-Disposition: attachment; filename="some-file-name.pdf"
+      Content-Disposition: attachment; filename="#{expected_filename}"
       Content-Transfer-Encoding: base64
 
       aGVsbG8gd29ybGQK
@@ -55,13 +55,30 @@ RSpec.describe RawMessage do
 
     EMAIL
   end
+  let(:filename) { 'some-file-name.jpg' }
+  let(:mimetype) { 'application/pdf' }
+  let(:expected_filename) { 'some-file-name.pdf' }
 
   it 'uses correct filename and extension' do
-    expect(subject.to_s).to include('some-file-name.pdf')
+    expect(subject.to_s).to include(expected_filename)
   end
 
   it 'creates the expected raw message' do
     expect(subject.to_s).to eq(expected_email)
+  end
+
+  context 'when filename has multiple fullstops' do
+    let(:filename) { 'Screenshot 2023-04-04 at 16.02.20.png' }
+    let(:mimetype) { 'application/pdf' }
+    let(:expected_filename) { 'Screenshot 2023-04-04 at 16.02.20.pdf' }
+
+    it 'uses maintains the filename' do
+      expect(subject.to_s).to include(expected_filename)
+    end
+
+    it 'creates the expected raw message' do
+      expect(subject.to_s).to eq(expected_email)
+    end
   end
 
   context 'when filename does not have extension' do


### PR DESCRIPTION
## Ensure only the last full stop is used when creating a filename with extension
A bug has been reported where if the attachment filename has more than one occurrence of a full stop, it appears as the wrong name in the final email attachment.

Eg:
Filename: 'Screenshot 2023-04-04 at 16.02.20.png' would appear as 'Screenshot 2023-04-04 at 160220.png' in the final email.

### Before
![before](https://user-images.githubusercontent.com/29227502/230146130-7cc1fd42-ab26-4686-b51e-541f242bddd7.png)

### After
![Screenshot 2023-04-05 at 17 38 44](https://user-images.githubusercontent.com/29227502/230146942-e3416755-af32-4bc3-ad20-379823f0bb05.png)
