### PR TITLE
Use service name instead of GOVUK in email headers

### DIFF
--- a/app/value_objects/v2/raw_message.rb
+++ b/app/value_objects/v2/raw_message.rb
@@ -81,7 +81,7 @@ module V2
                                                     text-decoration: none;
                                                     vertical-align:top;
                                                     display: inline-block;
-                                                    ">GOV.UK</span>
+                                                    ">#{service_name}</span>
                                                 </td>
                                             </tr>
                                         </table>
@@ -189,6 +189,12 @@ module V2
 
         #{Base64.encode64(File.open(attachment.path, 'rb', &:read))}
       RAW_ATTACHMENT
+    end
+
+    def service_name
+      # now that we allow special chars, we need to get the last occurence of <
+      index_of_left_angle_bracket = @from.rindex('<')
+      @from.slice(0..index_of_left_angle_bracket - 1).strip
     end
   end
 end

--- a/app/value_objects/v2/raw_message.rb
+++ b/app/value_objects/v2/raw_message.rb
@@ -61,7 +61,6 @@ module V2
                         <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
                             <tr>
                                 <td width="70" bgcolor="#0b0c0c" valign="middle">
-                                    <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" style="text-decoration: none;">
                                         <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
                                             <tr>
                                                 <td style="padding-left: 10px">

--- a/spec/value_objects/v2/raw_message_spec.rb
+++ b/spec/value_objects/v2/raw_message_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe V2::RawMessage do
                       <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
                           <tr>
                               <td width="70" bgcolor="#0b0c0c" valign="middle">
-                                  <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" style="text-decoration: none;">
                                       <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
                                           <tr>
                                               <td style="padding-left: 10px">

--- a/spec/value_objects/v2/raw_message_spec.rb
+++ b/spec/value_objects/v2/raw_message_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe V2::RawMessage do
   subject(:raw_message) do
     described_class.new(
-      from: 'sender@example.com',
+      from: 'Service name <sender@example.com>',
       to: 'reciver@example.com',
       subject: 'test email',
       body_parts: {
@@ -63,7 +63,7 @@ RSpec.describe V2::RawMessage do
                                                   text-decoration: none;
                                                   vertical-align:top;
                                                   display: inline-block;
-                                                  ">GOV.UK</span>
+                                                  ">Service name</span>
                                               </td>
                                           </tr>
                                       </table>
@@ -155,7 +155,7 @@ RSpec.describe V2::RawMessage do
   end
   let(:expected_email) do
     <<~RAW_MESSAGE
-      From: sender@example.com
+      From: Service name <sender@example.com>
       To: reciver@example.com
       Subject: test email
       Content-Type: multipart/mixed; boundary="NextPart"


### PR DESCRIPTION
Currently, our emails are sent with a generic GOVUK header that links to the GOVUK homepage.
We want to remove the generic GOVUK header and replace it with the service name. We also want to remove the link to the GOVUK homepage.

### Before
<img width="1083" alt="Screenshot 2023-07-11 at 10 39 12" src="https://github.com/ministryofjustice/fb-submitter/assets/29227502/6926b3bd-1041-499d-8f9c-39b352cfd89e">

### After
<img width="1090" alt="Screenshot 2023-07-11 at 10 42 36" src="https://github.com/ministryofjustice/fb-submitter/assets/29227502/ac4e369f-3a17-4090-9551-7341ee8eb769">

### CircleCI run
https://app.circleci.com/pipelines/github/ministryofjustice/fb-submitter/3372/workflows/daeedbaa-4961-495c-973f-60676ff3643f