### PR TITLE
chore: Tidy up and test coverage increase

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: no_comma
 
 Metrics/BlockLength:
-  ExcludedMethods: ['describe', 'context', 'let']
+  AllowedMethods: ['describe', 'context', 'let']
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false

--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -60,11 +60,6 @@ module Concerns
       ENV['MAX_IAT_SKEW_SECONDS'].to_i
     end
 
-    def service_token(service_slug)
-      service = ServiceTokenService.new(service_slug:)
-      service.get
-    end
-
     def public_key(service_slug)
       service = ServiceTokenService.new(service_slug:)
       public_key = service.public_key

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -7,6 +7,8 @@ class HealthController < ActionController::API
   def readiness
     if ActiveRecord::Base.connection && ActiveRecord::Base.connected?
       render plain: 'ready'
+    else
+      render plain: 'not_ready', status: :service_unavailable
     end
   end
 end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -3,7 +3,7 @@ class MetricsController < ActionController::Base
     response.set_header('Content-Type', 'text/plain; version=0.0.4')
     @stats = [delayed_jobs_stats, submission_stats].flatten
 
-    render 'metrics/show.text'
+    render 'metrics/show', formats: [:text]
   end
 
   private

--- a/app/services/attachment_parser_service.rb
+++ b/app/services/attachment_parser_service.rb
@@ -5,7 +5,7 @@ class AttachmentParserService
   end
 
   def execute
-    attachments.map do |attachment|
+    attachments.filter_map do |attachment|
       if @v2submission
         Attachment.new(
           url: attachment.fetch('url', nil),
@@ -24,7 +24,8 @@ class AttachmentParserService
         )
       end
     rescue KeyError
-      Rails.logger.error "Couldn\'t parse the attachment #{attachment} and will skip it"
+      Rails.logger.error "Couldn't parse the attachment #{attachment} and will skip it"
+      nil
     end
   end
 

--- a/app/services/pdf_payload_translator.rb
+++ b/app/services/pdf_payload_translator.rb
@@ -39,8 +39,4 @@ class PdfPayloadTranslator
   def human_value(answer)
     answer.is_a?(Array) ? answer.join("\n\n") : answer
   end
-
-  def service
-    decrypted_submission[:service]
-  end
 end

--- a/app/services/webhook_attachment_service.rb
+++ b/app/services/webhook_attachment_service.rb
@@ -11,8 +11,6 @@ class WebhookAttachmentService
       hash[:mimetype] = attachment.mimetype
       hash[:filename] = attachment.filename_with_extension
       hash
-    rescue NoMethodError
-      Rails.logger.error "Couldn\'t parse the attachment information #{attachment} and it won\'t be included"
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,12 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  error_messages:
+    record_not_found:
+      title: "I couldn't find the requested user_data in that service"
+    token_not_present:
+      title: No user_data could be found because the token was not provided
+    token_not_valid:
+      title: No user_data could be found because the token was not valid
+    internal_server_error:
+      title: Internal Server Error

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,27 @@
 version: '3.4'
 
+x-shared-variables: &shared-variables
+  DATABASE_URL: postgres://postgres:password@db/submitter_local
+  NOTIFY_EMAIL_GENERIC: 46a72b64-9541-4000-91a7-fa8a3fa10bf9
+  NOTIFY_EMAIL_RETURN_SETUP_EMAIL_TOKEN: 38f6a1cd-a810-4f59-8899-2c300236c5b4
+  NOTIFY_EMAIL_RETURN_SETUP_EMAIL_VERIFIED: ''
+  NOTIFY_EMAIL_RETURN_SETUP_MOBILE_VERIFIED: 54dcaad7-4967-431d-8606-72b0b80b5c6a
+  NOTIFY_EMAIL_RETURN_SIGNIN_EMAIL: ''
+  NOTIFY_EMAIL_RETURN_SIGNIN_SUCCESS: ''
+  NOTIFY_SMS_GENERIC: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+  NOTIFY_SMS_RETURN_SIGNIN_MOBILE: something
+  NOTIFY_SMS_RETURN_SETUP_MOBILE: 54dcaad7-4967-431d-8606-72b0b80b5c6a
+  FB_ENVIRONMENT_SLUG: test
+  SECRET_KEY_BASE: xxxyyy
+  SERVICE_TOKEN_CACHE_ROOT_URL: http://fake_service_token_cache_root_url/
+  PDF_GENERATOR_ROOT_URL: http://pdf-generator.com
+  ENCRYPTION_KEY: i6USnzeRKljfLMPbRlB2E9oikURx4ou3
+  ENCRYPTION_SALT: lGlcn9HabIducdpwlSHcM06e9gFuIfS1Ogg5krtn1Fw=
+  MAX_IAT_SKEW_SECONDS: 60
+
 services:
   db:
-    image: postgres:10.9-alpine
+    image: postgres:14.6-alpine
     restart: always
     environment:
       POSTGRES_PASSWORD: password
@@ -18,24 +37,7 @@ services:
         BUNDLE_ARGS: ''
     user: "${UID}:${UID}"
     environment:
-      DATABASE_URL: "postgres://postgres:password@db/submitter_local"
-      NOTIFY_EMAIL_GENERIC: '46a72b64-9541-4000-91a7-fa8a3fa10bf9'
-      NOTIFY_EMAIL_RETURN_SETUP_EMAIL_TOKEN: '38f6a1cd-a810-4f59-8899-2c300236c5b4'
-      NOTIFY_EMAIL_RETURN_SETUP_EMAIL_VERIFIED: ''
-      NOTIFY_EMAIL_RETURN_SETUP_MOBILE_VERIFIED: '54dcaad7-4967-431d-8606-72b0b80b5c6a'
-      NOTIFY_EMAIL_RETURN_SIGNIN_EMAIL: ''
-      NOTIFY_EMAIL_RETURN_SIGNIN_SUCCESS: ''
-      NOTIFY_SMS_GENERIC: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
-      NOTIFY_SMS_RETURN_SETUP_MOBILE: '54dcaad7-4967-431d-8606-72b0b80b5c6a'
-      NOTIFY_SMS_RETURN_SIGNIN_MOBILE: 'something'
-      NOTIFY_SMS_RETURN_SETUP_MOBILE: '54dcaad7-4967-431d-8606-72b0b80b5c6a'
-      FB_ENVIRONMENT_SLUG: 'test'
-      SECRET_KEY_BASE: 'xxxyyy'
-      SERVICE_TOKEN_CACHE_ROOT_URL: "http://fake_service_token_cache_root_url/"
-      PDF_GENERATOR_ROOT_URL: 'http://pdf-generator.com'
-      ENCRYPTION_KEY: 'i6USnzeRKljfLMPbRlB2E9oikURx4ou3'
-      ENCRYPTION_SALT: 'lGlcn9HabIducdpwlSHcM06e9gFuIfS1Ogg5krtn1Fw='
-      MAX_IAT_SKEW_SECONDS: 60
+      <<: *shared-variables
       SUBMISSION_DECRYPTION_KEY: eRIF8glaggYMluja
     links:
       - db
@@ -45,23 +47,6 @@ services:
       context: .
       dockerfile: ./docker/workers/Dockerfile
     environment:
-      DATABASE_URL: "postgres://postgres:password@db/submitter_local"
-      NOTIFY_EMAIL_GENERIC: '46a72b64-9541-4000-91a7-fa8a3fa10bf9'
-      NOTIFY_EMAIL_RETURN_SETUP_EMAIL_TOKEN: '38f6a1cd-a810-4f59-8899-2c300236c5b4'
-      NOTIFY_EMAIL_RETURN_SETUP_EMAIL_VERIFIED: ''
-      NOTIFY_EMAIL_RETURN_SETUP_MOBILE_VERIFIED: '54dcaad7-4967-431d-8606-72b0b80b5c6a'
-      NOTIFY_EMAIL_RETURN_SIGNIN_EMAIL: ''
-      NOTIFY_EMAIL_RETURN_SIGNIN_SUCCESS: ''
-      NOTIFY_SMS_GENERIC: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
-      NOTIFY_SMS_RETURN_SETUP_MOBILE: '54dcaad7-4967-431d-8606-72b0b80b5c6a'
-      NOTIFY_SMS_RETURN_SIGNIN_MOBILE: 'something'
-      NOTIFY_SMS_RETURN_SETUP_MOBILE: '54dcaad7-4967-431d-8606-72b0b80b5c6a'
-      SERVICE_TOKEN_CACHE_ROOT_URL: 'http://service-token-cache.com'
-      FB_ENVIRONMENT_SLUG: 'test'
-      SECRET_KEY_BASE: 'xxxyyy'
-      PDF_GENERATOR_ROOT_URL: 'http://pdf-generator.com'
-      ENCRYPTION_KEY: 'i6USnzeRKljfLMPbRlB2E9oikURx4ou3'
-      ENCRYPTION_SALT: 'lGlcn9HabIducdpwlSHcM06e9gFuIfS1Ogg5krtn1Fw='
-      MAX_IAT_SKEW_SECONDS: 60
+      <<: *shared-variables
     links:
       - db

--- a/spec/controllers/concerns/error_handling_spec.rb
+++ b/spec/controllers/concerns/error_handling_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe 'Concerns::ErrorHandling' do
+  let(:parsed_body) { JSON.parse(response.body) }
+
+  controller do
+    include Concerns::ErrorHandling
+
+    def standard_error
+      raise StandardError, 'boom!'
+    end
+
+    def record_not_found
+      raise ActiveRecord::RecordNotFound, 'not found!'
+    end
+  end
+
+  describe 'rescue from StandardError' do
+    let(:is_prod_env) { false }
+
+    before do
+      routes.draw { get 'standard_error' => 'anonymous#standard_error' }
+
+      allow(Rails.env).to receive(:production?).and_return(is_prod_env)
+      allow(Sentry).to receive(:capture_exception)
+
+      get :standard_error
+    end
+
+    it 'has status 500' do
+      expect(response).to have_http_status(:internal_server_error)
+    end
+
+    describe 'the body' do
+      it 'is valid JSON' do
+        expect { parsed_body }.not_to raise_error
+      end
+
+      describe 'exception details' do
+        context 'when running in a production environment' do
+          let(:is_prod_env) { true }
+
+          it 'has the details of the exception' do
+            expect(parsed_body.fetch('errors').first.keys).to match_array(%w[message status title])
+          end
+        end
+
+        context 'when running in a non-production environment' do
+          it 'has the details of the exception' do
+            expect(parsed_body.fetch('errors').first.keys).to match_array(%w[detail location message status title])
+          end
+        end
+      end
+
+      it 'has a message indicating the error' do
+        expect(parsed_body.fetch('errors').first.fetch('title')).to eq(
+          I18n.t(:title, scope: %i[error_messages internal_server_error])
+        )
+      end
+
+      it 'reports the exception' do
+        expect(Sentry).to have_received(:capture_exception).with(
+          an_instance_of(StandardError)
+        )
+      end
+    end
+  end
+
+  describe 'rescue from RecordNotFound' do
+    before do
+      routes.draw { get 'record_not_found' => 'anonymous#record_not_found' }
+      allow(Sentry).to receive(:capture_exception)
+      get :record_not_found
+    end
+
+    it 'has status 404' do
+      expect(response).to have_http_status(:not_found)
+    end
+
+    describe 'the body' do
+      it 'is valid JSON' do
+        expect { parsed_body }.not_to raise_error
+      end
+
+      it 'has the details of the exception' do
+        expect(parsed_body.fetch('errors').first.keys).to match_array(%w[status title])
+      end
+
+      it 'has a message indicating the error' do
+        expect(parsed_body.fetch('errors').first.fetch('title')).to eq(
+          I18n.t(:title, scope: %i[error_messages record_not_found])
+        )
+      end
+
+      it 'does not report the exception' do
+        expect(Sentry).not_to have_received(:capture_exception)
+      end
+    end
+  end
+end

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -12,4 +12,34 @@ describe HealthController do
       expect(response.body).to eq('healthy')
     end
   end
+
+  describe 'GET #readiness' do
+    context 'when the database is up and running' do
+      it 'returns 200 OK' do
+        get :readiness
+        expect(response.status).to eq(200)
+      end
+
+      it 'returns `ready` body' do
+        get :readiness
+        expect(response.body).to eq('ready')
+      end
+    end
+
+    context 'when the database is not ready yet' do
+      before do
+        allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
+      end
+
+      it 'returns 503 service unavailable' do
+        get :readiness
+        expect(response.status).to eq(503)
+      end
+
+      it 'returns `not_ready` body' do
+        get :readiness
+        expect(response.body).to eq('not_ready')
+      end
+    end
+  end
 end

--- a/spec/jobs/v2/process_submission_job_spec.rb
+++ b/spec/jobs/v2/process_submission_job_spec.rb
@@ -146,5 +146,22 @@ RSpec.describe V2::ProcessSubmissionJob do
         end
       end
     end
+
+    context 'when the action is not recognised' do
+      let(:encrypted_payload) do
+        fixture = payload_fixture
+        fixture['actions'] = [{ 'kind' => 'foobar' }]
+        SubmissionEncryption.new(key:).encrypt(fixture)
+      end
+
+      before do
+        allow(Rails.logger).to receive(:warn)
+        perform_job
+      end
+
+      it 'logs a warning' do
+        expect(Rails.logger).to have_received(:warn).with(/Unknown action type/)
+      end
+    end
   end
 end

--- a/spec/services/adapters/mock_amazon_ses_adapter_spec.rb
+++ b/spec/services/adapters/mock_amazon_ses_adapter_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Adapters::MockAmazonSESAdapter do
+  subject(:mock) { described_class }
+
+  let(:http_client_class) { Typhoeus }
+
+  describe '.send_email' do
+    let(:endpoint) { 'http://endpoint_override' }
+    let(:body) { { foo: 'bar' } }
+
+    before do
+      allow(ENV).to receive(:fetch).with('EMAIL_ENDPOINT_OVERRIDE').and_return(endpoint)
+      allow(http_client_class).to receive(:post)
+    end
+
+    it 'performs the POST with the expected endpoint and body' do
+      mock.send_mail(body)
+
+      expect(
+        http_client_class
+      ).to have_received(:post).with(endpoint, body:)
+    end
+  end
+end

--- a/spec/services/webhook_attachment_service_spec.rb
+++ b/spec/services/webhook_attachment_service_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 describe WebhookAttachmentService do
   subject(:service) { described_class.new(attachment_parser:, user_file_store_gateway:) }
 
@@ -58,7 +60,7 @@ describe WebhookAttachmentService do
       expect(service.execute).to eq(expected_attachments)
     end
 
-    it 'calls parser to get attachements' do
+    it 'calls parser to get attachments' do
       service.execute
       expect(attachment_parser).to have_received(:execute).once
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,7 +110,7 @@ SimpleCov.start do
   add_filter '/spec/'
 end
 
-SimpleCov.minimum_coverage 97
+SimpleCov.minimum_coverage 100
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::Console


### PR DESCRIPTION
A series of commits to remove some deprecation warnings, get to 100% test coverage and to fix/DRY the `docker-compose.yml` (there was a duplicated ENV variable).

Individual commits for more context.

- To run the tests in this repo some containers are needed: `make spec` (as per README)
- Rubocop: `bundle exec rubocop`

**NOTE**: I've set the spec coverage to 100 (up from 97). I believe this is a good practise otherwise slowly we will be falling behind again. However I'm mindful sometimes this might not be desirable so happy to change it back, or we can wait and see how we feel about it. I think 97 was pretty good regardless!

Before:
<img width="781" alt="Screenshot 2023-10-27 at 11 42 29" src="https://github.com/ministryofjustice/fb-submitter/assets/687910/801e9722-31d1-4d1f-aa65-df388e14d685">

After:
<img width="770" alt="Screenshot 2023-10-30 at 12 54 34" src="https://github.com/ministryofjustice/fb-submitter/assets/687910/8cbfc8bb-e5f8-4fd6-86ac-8ae92ebea9cc">
