### PR TITLE
Propagate request_id to filestore service

### DIFF
--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -8,11 +8,17 @@ module V2
       @request_id = options[:request_id]
       @jwt_skew_override = options[:jwt_skew_override]
 
+      Sentry.set_tags(request_id:)
+
       submission = Submission.find(submission_id)
       decrypted_submission = submission.decrypted_submission.merge('submission_id' => submission.id)
       payload_service = V2::SubmissionPayloadService.new(decrypted_submission)
 
+      Sentry.set_context('attachments', { size: payload_service.attachments.size })
+
       decrypted_submission['actions'].each do |action|
+        Sentry.set_context('action_payload', action.slice('kind', 'include_attachments', 'include_pdf'))
+
         case action['kind']
         when 'json'
           JsonWebhookService.new(

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -24,7 +24,7 @@ module V2
           JsonWebhookService.new(
             webhook_attachment_fetcher: WebhookAttachmentService.new(
               attachment_parser: AttachmentParserService.new(attachments: payload_service.attachments, v2submission: true),
-              user_file_store_gateway: Adapters::UserFileStore.new(key: submission.encrypted_user_id_and_token)
+              user_file_store_gateway: Adapters::UserFileStore.new(key: submission.encrypted_user_id_and_token, request_id:)
             ),
             webhook_destination_adapter: Adapters::JweWebhookDestination.new(
               url: action['url'],

--- a/app/services/adapters/user_file_store.rb
+++ b/app/services/adapters/user_file_store.rb
@@ -2,17 +2,17 @@ module Adapters
   class UserFileStore
     class ClientRequestError < StandardError; end
 
-    def initialize(key:)
+    attr_reader :key, :request_id
+
+    def initialize(key:, request_id: nil)
       @key = key
+      @request_id = request_id
     end
 
     def get_presigned_url(url)
       signed_url = "#{url}/presigned-s3-url"
-      response = Typhoeus::Request.new(
-        signed_url,
-        headers: { 'x-encrypted-user-id-and-token': @key },
-        method: :post
-      ).run
+      response = Typhoeus::Request.new(signed_url, headers:, method: :post).run
+
       raise ClientRequestError, "Request for #{signed_url} returned response status of: #{response&.code}" unless response.success?
 
       json = JSON.parse(response.body).symbolize_keys!
@@ -20,6 +20,16 @@ module Adapters
         url: json.fetch(:url),
         encryption_key: json.fetch(:encryption_key),
         encryption_iv: json.fetch(:encryption_iv)
+      }
+    end
+
+    private
+
+    def headers
+      {
+        'x-encrypted-user-id-and-token' => key,
+        'X-Request-Id' => request_id,
+        'User-Agent' => 'Submitter'
       }
     end
   end

--- a/spec/services/adapters/user_file_store_spec.rb
+++ b/spec/services/adapters/user_file_store_spec.rb
@@ -1,5 +1,5 @@
 describe Adapters::UserFileStore do
-  subject(:adaptor) { described_class.new(key:) }
+  subject(:adaptor) { described_class.new(key:, request_id:) }
 
   before do
     stub_request(:post, requested_url).to_return(body: { url: 'foo', encryption_key: 'bar', encryption_iv: 'baz' }.to_json)
@@ -7,6 +7,7 @@ describe Adapters::UserFileStore do
 
   let(:url) { "https://the-url/#{SecureRandom.alphanumeric(10)}" }
   let(:key) { SecureRandom.alphanumeric(10) }
+  let(:request_id) { '12345' }
   let(:requested_url) { "#{url}/presigned-s3-url" }
 
   it 'posts to the user file store endpoint' do
@@ -18,8 +19,9 @@ describe Adapters::UserFileStore do
     adaptor.get_presigned_url(url)
     expect(WebMock).to have_requested(:post, requested_url).with(headers: {
       'x-encrypted-user-id-and-token': key,
-      'Expect': '',
-      'User-Agent': 'Typhoeus - https://github.com/typhoeus/typhoeus'
+      'X-Request-Id': request_id,
+      'User-Agent': 'Submitter',
+      'Expect': ''
     })
   end
 


### PR DESCRIPTION
Propagate the `request_id` to filestore service from the Webhook service.
This propagation was missed in the previous PR.

Also added a bit more sentry context to the job in case there are exceptions reported.