### PR TITLE
Support JSON objects in answers (addresses)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,7 @@ workflows:
             branches:
               only:
                 - main
+                - address-json
       - build_and_push_worker_image:
           context: *context
           requires:
@@ -268,6 +269,7 @@ workflows:
             branches:
               only:
                 - main
+                - address-json
       - deploy_to_test_dev:
           context: *context
           requires:
@@ -278,29 +280,29 @@ workflows:
           requires:
             - build_and_push_image
             - build_and_push_worker_image
-      - acceptance_tests:
-          context: *context
-          requires:
-            - deploy_to_test_dev
-            - deploy_to_test_production
-      - deploy_to_live_dev:
-          context: *context
-          requires:
-            - acceptance_tests
-          filters:
-            branches:
-              only:
-                - main
-      - deploy_to_live_production:
-          context: *context
-          requires:
-            - acceptance_tests
-          filters:
-            branches:
-              only:
-                - main
-      - smoke_tests:
-          context: *context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+#      - acceptance_tests:
+#          context: *context
+#          requires:
+#            - deploy_to_test_dev
+#            - deploy_to_test_production
+#      - deploy_to_live_dev:
+#          context: *context
+#          requires:
+#            - acceptance_tests
+#          filters:
+#            branches:
+#              only:
+#                - main
+#      - deploy_to_live_production:
+#          context: *context
+#          requires:
+#            - acceptance_tests
+#          filters:
+#            branches:
+#              only:
+#                - main
+#      - smoke_tests:
+#          context: *context
+#          requires:
+#            - deploy_to_live_dev
+#            - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,11 +280,11 @@ workflows:
           requires:
             - build_and_push_image
             - build_and_push_worker_image
-#      - acceptance_tests:
-#          context: *context
-#          requires:
-#            - deploy_to_test_dev
-#            - deploy_to_test_production
+      - acceptance_tests:
+          context: *context
+          requires:
+            - deploy_to_test_dev
+            - deploy_to_test_production
 #      - deploy_to_live_dev:
 #          context: *context
 #          requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,6 @@ workflows:
             branches:
               only:
                 - main
-                - address-json
       - build_and_push_worker_image:
           context: *context
           requires:
@@ -269,7 +268,6 @@ workflows:
             branches:
               only:
                 - main
-                - address-json
       - deploy_to_test_dev:
           context: *context
           requires:
@@ -285,24 +283,24 @@ workflows:
           requires:
             - deploy_to_test_dev
             - deploy_to_test_production
-#      - deploy_to_live_dev:
-#          context: *context
-#          requires:
-#            - acceptance_tests
-#          filters:
-#            branches:
-#              only:
-#                - main
-#      - deploy_to_live_production:
-#          context: *context
-#          requires:
-#            - acceptance_tests
-#          filters:
-#            branches:
-#              only:
-#                - main
-#      - smoke_tests:
-#          context: *context
-#          requires:
-#            - deploy_to_live_dev
-#            - deploy_to_live_production
+      - deploy_to_live_dev:
+          context: *context
+          requires:
+            - acceptance_tests
+          filters:
+            branches:
+              only:
+                - main
+      - deploy_to_live_production:
+          context: *context
+          requires:
+            - acceptance_tests
+          filters:
+            branches:
+              only:
+                - main
+      - smoke_tests:
+          context: *context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/app/services/pdf_payload_translator.rb
+++ b/app/services/pdf_payload_translator.rb
@@ -37,6 +37,12 @@ class PdfPayloadTranslator
   end
 
   def human_value(answer)
-    answer.is_a?(Array) ? answer.join("\n\n") : answer
+    if answer.is_a?(Array)
+      answer.join("\r\n")
+    elsif answer.is_a?(Hash)
+      answer.values.compact_blank.join("\r\n")
+    else
+      answer
+    end
   end
 end

--- a/app/services/pdf_payload_translator.rb
+++ b/app/services/pdf_payload_translator.rb
@@ -40,7 +40,7 @@ class PdfPayloadTranslator
     if answer.is_a?(Array)
       answer.join("\r\n")
     elsif answer.is_a?(Hash)
-      answer.values.compact_blank.join("\r\n")
+      answer.values.compact_blank.join(', ')
     else
       answer
     end

--- a/schemas/submission_payload.json
+++ b/schemas/submission_payload.json
@@ -173,6 +173,7 @@
           "description": "The user answer",
           "oneOf": [
             { "type": "string" },
+            { "type": "object" },
             {
               "type": "array",
               "items": { "type": "string" }

--- a/spec/fixtures/payloads/pdf_generator.json
+++ b/spec/fixtures/payloads/pdf_generator.json
@@ -18,7 +18,7 @@
       "questions":[
          {
            "label":"What would you like on your burger?",
-           "human_value":"Beef, cheese, tomato\n\nMozzarella, cheddar, feta"
+           "human_value":"Beef, cheese, tomato\r\nMozzarella, cheddar, feta"
          }
       ]
     },
@@ -37,6 +37,16 @@
         {
           "label": "Multiple Question 3",
           "human_value": "BB8"
+        }
+      ]
+    },
+    {
+      "heading": "",
+      "summary_heading": "",
+      "questions": [
+        {
+          "label": "Your postal address",
+          "human_value": "1 road\r\nruby town\r\n99 999\r\nruby land"
         }
       ]
     }

--- a/spec/fixtures/payloads/pdf_generator.json
+++ b/spec/fixtures/payloads/pdf_generator.json
@@ -46,7 +46,7 @@
       "questions": [
         {
           "label": "Your postal address",
-          "human_value": "1 road\r\nruby town\r\n99 999\r\nruby land"
+          "human_value": "1 road, ruby town, 99 999, ruby land"
         }
       ]
     }

--- a/spec/fixtures/payloads/valid_submission.json
+++ b/spec/fixtures/payloads/valid_submission.json
@@ -74,6 +74,23 @@
           "answer": "BB8"
         }
       ]
+    },
+    {
+      "heading": "",
+      "answers": [
+        {
+          "field_id": "postal-address_address_1",
+          "field_name": "Your postal address",
+          "answer": {
+            "address_line_one": "1 road",
+            "address_line_two": "",
+            "city": "ruby town",
+            "county": "",
+            "postcode": "99 999",
+            "country": "ruby land"
+          }
+        }
+      ]
     }
   ],
   "attachments": [

--- a/spec/services/v2/generate_csv_content_spec.rb
+++ b/spec/services/v2/generate_csv_content_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe V2::GenerateCsvContent do
               'answer' => "Zombie ipsum reversus ab viral inferno, nam rick grimes malum cerebro.\n\r\nDe carne lumbering animata corpora quaeritis.\n\r\nSummus brains sit, morbo vel maleficia?"
             }
           ]
+        },
+        {
+          'heading' => 'Your postal address',
+          'answers' => [
+            {
+              'field_id' => 'postal-address_address_1',
+              'answer' => {
+                'address_line_one' => '1 road',
+                'address_line_two' => '',
+                'city' => "ruby\r\ntown",
+                'county' => '',
+                'postcode' => '99 999',
+                'country' => 'ruby land'
+              }
+            }
+          ]
         }
       ]
     }.merge(meta)
@@ -60,6 +76,12 @@ RSpec.describe V2::GenerateCsvContent do
         name_text_2
         your-email-address_text_1
         life-history_textarea_1
+        postal-address_address_1/address_line_one
+        postal-address_address_1/address_line_two
+        postal-address_address_1/city
+        postal-address_address_1/county
+        postal-address_address_1/postcode
+        postal-address_address_1/country
       ]
     end
     let(:expected_column_1) do
@@ -69,7 +91,13 @@ RSpec.describe V2::GenerateCsvContent do
         'Stormtrooper',
         'FN-some-last-name',
         'fb-acceptance-tests@digital.justice.gov.uk',
-        'Zombie ipsum reversus ab viral inferno, nam rick grimes malum cerebro. De carne lumbering animata corpora quaeritis. Summus brains sit, morbo vel maleficia?'
+        'Zombie ipsum reversus ab viral inferno, nam rick grimes malum cerebro. De carne lumbering animata corpora quaeritis. Summus brains sit, morbo vel maleficia?',
+        '1 road',
+        '',
+        'ruby town',
+        '',
+        '99 999',
+        'ruby land'
       ]
     end
 

--- a/spec/services/v2/submission_payload_service_spec.rb
+++ b/spec/services/v2/submission_payload_service_spec.rb
@@ -68,6 +68,23 @@ RSpec.describe V2::SubmissionPayloadService do
               'answer' => 'fb-acceptance-tests@digital.justice.gov.uk'
             }
           ]
+        },
+        {
+          'heading' => '',
+          'answers' => [
+            {
+              'field_id' => 'postal-address_address_1',
+              'field_name' => 'Your postal address',
+              'answer' => {
+                'address_line_one' => '1 road',
+                'address_line_two' => '',
+                'city' => 'ruby town',
+                'county' => '',
+                'postcode' => '99 999',
+                'country' => 'ruby land'
+              }
+            }
+          ]
         }
       ],
       'attachments' => [
@@ -99,7 +116,15 @@ RSpec.describe V2::SubmissionPayloadService do
       {
         'name_text_1' => 'Stormtrooper',
         'name_text_2' => 'FN-b0046eb3-37ff-400d-85f8-8bbb5c11183b',
-        'your-email-address_text_1' => 'fb-acceptance-tests@digital.justice.gov.uk'
+        'your-email-address_text_1' => 'fb-acceptance-tests@digital.justice.gov.uk',
+        'postal-address_address_1' => {
+          'address_line_one' => '1 road',
+          'address_line_two' => '',
+          'city' => 'ruby town',
+          'county' => '',
+          'postcode' => '99 999',
+          'country' => 'ruby land'
+        }
       }
     end
 


### PR DESCRIPTION
https://trello.com/c/vOJZ2MRo

We need to support payloads with answers being hashes, and properly translate it for the CSV and the PDF.

This so far only applies to address components. Up until now we were sending in the payload a string concatenating the parts of the address, but we need a structured hash with each of the individual fields so API adapters receive it intact.