### PR TITLE
Sent payloads to MS List

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,7 @@ workflows:
             branches:
               only:
                 - main
+                - ms-list-submission
       - build_and_push_worker_image:
           context: *context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,6 @@ workflows:
             branches:
               only:
                 - main
-                - ms-list-submission
       - build_and_push_worker_image:
           context: *context
           requires:
@@ -269,7 +268,6 @@ workflows:
             branches:
               only:
                 - main
-                - ms-list-submission
       - deploy_to_test_dev:
           context: *context
           requires:
@@ -285,24 +283,24 @@ workflows:
           requires:
             - deploy_to_test_dev
             - deploy_to_test_production
-      # - deploy_to_live_dev:
-      #     context: *context
-      #     requires:
-      #       - acceptance_tests
-      #     filters:
-      #       branches:
-      #         only:
-      #           - main
-      # - deploy_to_live_production:
-      #     context: *context
-      #     requires:
-      #       - acceptance_tests
-      #     filters:
-      #       branches:
-      #         only:
-      #           - main
-      # - smoke_tests:
-      #     context: *context
-      #     requires:
-      #       - deploy_to_live_dev
-      #       - deploy_to_live_production
+      - deploy_to_live_dev:
+          context: *context
+          requires:
+            - acceptance_tests
+          filters:
+            branches:
+              only:
+                - main
+      - deploy_to_live_production:
+          context: *context
+          requires:
+            - acceptance_tests
+          filters:
+            branches:
+              only:
+                - main
+      - smoke_tests:
+          context: *context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,7 @@ workflows:
             branches:
               only:
                 - main
+                - ms-list-submission
       - deploy_to_test_dev:
           context: *context
           requires:
@@ -283,24 +284,24 @@ workflows:
           requires:
             - deploy_to_test_dev
             - deploy_to_test_production
-      - deploy_to_live_dev:
-          context: *context
-          requires:
-            - acceptance_tests
-          filters:
-            branches:
-              only:
-                - main
-      - deploy_to_live_production:
-          context: *context
-          requires:
-            - acceptance_tests
-          filters:
-            branches:
-              only:
-                - main
-      - smoke_tests:
-          context: *context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+      # - deploy_to_live_dev:
+      #     context: *context
+      #     requires:
+      #       - acceptance_tests
+      #     filters:
+      #       branches:
+      #         only:
+      #           - main
+      # - deploy_to_live_production:
+      #     context: *context
+      #     requires:
+      #       - acceptance_tests
+      #     filters:
+      #       branches:
+      #         only:
+      #           - main
+      # - smoke_tests:
+      #     context: *context
+      #     requires:
+      #       - deploy_to_live_dev
+      #       - deploy_to_live_production

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,5 +37,8 @@ Metrics/BlockLength:
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
+RSpec/ExampleLength:
+  Enabled: false
+
 Style/RedundantParentheses:
   Enabled: false

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -76,11 +76,13 @@ module V2
               submission.access_token
             )
 
+            created_folder = create_folder_in_drive(submission.id)
+
             attachments.each do |attachment|
               Rails.logger.info('*****************')
               Rails.logger.info('Posting attachment')
               Rails.logger.info(attachment.filename)
-              send_attachment_to_drive(attachment, submission.id)
+              send_attachment_to_drive(attachment, submission.id, created_folder)
             end
           end
 
@@ -122,7 +124,7 @@ module V2
       )
     end
 
-    delegate :send_attachment_to_drive, :post_to_ms_list, to: :ms_graph_adapter
+    delegate :send_attachment_to_drive, :post_to_ms_list, :create_folder_in_drive, to: :ms_graph_adapter
 
     def ms_graph_adapter(action = nil)
       @ms_graph_adapter ||= V2::SendToMsGraphService.new(action)

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -89,9 +89,7 @@ module V2
           #     send_attachments_to_drive(attachment)
           #   end
           # end
-          Rails.logger.info('*****************')
-          Rails.logger.info('Sending submission')
-          Rails.logger.info(submission)
+
           Rails.logger.info('*****************')
           Rails.logger.info(decrypted_submission)
           Rails.logger.info('*****************')

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -89,11 +89,6 @@ module V2
           #     send_attachments_to_drive(attachment)
           #   end
           # end
-
-          Rails.logger.info('*****************')
-          Rails.logger.info(decrypted_submission)
-          Rails.logger.info('*****************')
-          Rails.logger.info('*****************')
           post_to_ms_list(decrypted_submission, submission.id)
           # end
         else

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -96,7 +96,7 @@ module V2
           Rails.logger.info(decrypted_submission)
           Rails.logger.info('*****************')
           Rails.logger.info('*****************')
-          send_to_ms_list(submission:)
+          post_to_ms_list(decrypted_submission, submission.id)
           # end
         else
           Rails.logger.warn "Unknown action type '#{action}' for submission id #{submission.id}"
@@ -128,11 +128,7 @@ module V2
       )
     end
 
-    def send_to_ms_list(submission)
-      ms_graph_adapter.post_to_ms_list(submission)
-    end
-
-    delegate :send_attachment_to_drive, to: :ms_graph_adapter
+    delegate :send_attachment_to_drive, :post_to_ms_list, to: :ms_graph_adapter
 
     def ms_graph_adapter(action = nil)
       @ms_graph_adapter ||= V2::SendToMsGraphService.new(action)

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -70,8 +70,6 @@ module V2
           ms_graph_adapter(action)
 
           if action['include_attachments'] == true
-            Rails.logger.info('*****************')
-            Rails.logger.info('Posting attachments')
             attachments = download_attachments(
               decrypted_submission['attachments'],
               submission.encrypted_user_id_and_token,
@@ -79,6 +77,9 @@ module V2
             )
 
             attachments.each do |attachment|
+              Rails.logger.info('*****************')
+              Rails.logger.info('Posting attachment')
+              Rails.logger.info(attachment.filename)
               send_attachment_to_drive(attachment)
             end
           end

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -65,9 +65,13 @@ module V2
 
           send_email(submission:, action:, attachments: [csv_attachment])
         when 'mslist'
+          Rails.logger.info('*****************')
+          Rails.logger.info('Creating adapter')
           ms_graph_adapter(action)
 
           if action['include_attachments'] == true
+            Rails.logger.info('*****************')
+            Rails.logger.info('Posting attachments')
             attachments = download_attachments(
               decrypted_submission['attachments'],
               submission.encrypted_user_id_and_token,
@@ -85,6 +89,8 @@ module V2
           #     send_attachments_to_drive(attachment)
           #   end
           # end
+          Rails.logger.info('*****************')
+          Rails.logger.info('Sending submission')
           send_to_ms_list(submission:)
           # end
         else

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -91,6 +91,11 @@ module V2
           # end
           Rails.logger.info('*****************')
           Rails.logger.info('Sending submission')
+          Rails.logger.info(submission)
+          Rails.logger.info('*****************')
+          Rails.logger.info(decrypted_submission)
+          Rails.logger.info('*****************')
+          Rails.logger.info('*****************')
           send_to_ms_list(submission:)
           # end
         else

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -65,6 +65,7 @@ module V2
 
           send_email(submission:, action:, attachments: [csv_attachment])
         when 'mslist'
+          ms_graph_adapter(action)
 
           if action['include_attachments'] == true
             attachments = download_attachments(
@@ -122,8 +123,8 @@ module V2
 
     delegate :send_attachment_to_drive, to: :ms_graph_adapter
 
-    def ms_graph_adapter
-      @ms_graph_adapter ||= V2::SendToMsGraphService.new
+    def ms_graph_adapter(action = nil)
+      @ms_graph_adapter ||= V2::SendToMsGraphService.new(action)
     end
   end
 end

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -65,8 +65,6 @@ module V2
 
           send_email(submission:, action:, attachments: [csv_attachment])
         when 'mslist'
-          Rails.logger.info('*****************')
-          Rails.logger.info('Creating adapter')
           ms_graph_adapter(action)
 
           if action['include_attachments'] == true
@@ -79,21 +77,11 @@ module V2
             created_folder = create_folder_in_drive(submission.id)
 
             attachments.each do |attachment|
-              Rails.logger.info('*****************')
-              Rails.logger.info('Posting attachment')
-              Rails.logger.info(attachment.filename)
               send_attachment_to_drive(attachment, submission.id, created_folder)
             end
           end
 
-          # if send_to_ms_list(submission:)
-          # if action['include_attachments'] == true
-          #   attachments.each do |attachment|
-          #     send_attachments_to_drive(attachment)
-          #   end
-          # end
           post_to_ms_list(decrypted_submission, submission.id)
-          # end
         else
           Rails.logger.warn "Unknown action type '#{action}' for submission id #{submission.id}"
         end

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -80,7 +80,7 @@ module V2
               Rails.logger.info('*****************')
               Rails.logger.info('Posting attachment')
               Rails.logger.info(attachment.filename)
-              send_attachment_to_drive(attachment)
+              send_attachment_to_drive(attachment, submission.id)
             end
           end
 

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -65,7 +65,6 @@ module V2
 
           send_email(submission:, action:, attachments: [csv_attachment])
         when 'mslist'
-          attachments = []
 
           if action['include_attachments'] == true
             attachments = download_attachments(
@@ -80,11 +79,11 @@ module V2
           end
 
           # if send_to_ms_list(submission:)
-            # if action['include_attachments'] == true
-            #   attachments.each do |attachment|
-            #     send_attachments_to_drive(attachment)
-            #   end
-            # end
+          # if action['include_attachments'] == true
+          #   attachments.each do |attachment|
+          #     send_attachments_to_drive(attachment)
+          #   end
+          # end
           send_to_ms_list(submission:)
           # end
         else
@@ -121,12 +120,10 @@ module V2
       ms_graph_adapter.post_to_ms_list(submission)
     end
 
-    def send_attachment_to_drive(attachment)
-      ms_graph_adapter.send_attachment_to_drive(attachment)
-    end
+    delegate :send_attachment_to_drive, to: :ms_graph_adapter
 
     def ms_graph_adapter
-      @ms_graph_adapter ||= V2::SendToMsGraphService.new()
+      @ms_graph_adapter ||= V2::SendToMsGraphService.new
     end
   end
 end

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -99,7 +99,7 @@ module V2
         result_hash.merge!(hash)
       end
 
-      new_data['fields'].merge!(result_hash)
+      new_data['fields'].merge!(result_hash.to_json)
     end
 
     private

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -49,7 +49,7 @@ module V2
       response = @connection.post do |req|
         req.headers['Content-Type'] = 'text/plain'
         req.headers['Authorization'] = "Bearer #{get_auth_token}"
-        req.body = attachment
+        req.body = File.read(attachment.file)
       end
 
       parsed_response = JSON.parse(response.body)

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -79,7 +79,7 @@ module V2
 
       submission['pages'].each do |page|
         page['answers'].each do |answer|
-          keystring = answer['field_name'].to_s
+          keystring = answer['field_id'].to_s
           md5name = Digest::MD5.hexdigest keystring
           md5stripped = md5name.tr('0-9', '')
           merge_data << { md5stripped => answer['answer'] }

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -57,8 +57,6 @@ module V2
       connection = Faraday.new(uri) do |conn|
       end
 
-      Rails.logger.info("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{filename}:/content")
-      # byebug
       response = connection.put do |req|
         req.headers['Content-Type'] = 'text/plain'
         req.headers['Authorization'] = "Bearer #{get_auth_token}"

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -80,7 +80,7 @@ module V2
     def ms_list_payload(submission, id)
       new_data = {
         'fields' => {
-          'Title' => id
+          Digest::MD5.hexdigest('Submission ID').tr('0-9', '') => id
         }
       }
 

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -1,0 +1,89 @@
+module V2
+  class SendToMsGraphService
+    attr_accessor :site_id, :list_id, :drive_id, :root_graph_url
+    
+    def initialize(root_graph_url: ENV['MS_GRAPH_ROOT_URL'], site_id: ENV['MS_SITE_ID'], list_id: ENV['MS_LIST_ID'], drive_id: ENV['MS_DRIVE_ID'])
+      @root_graph_url = root_graph_url
+      @site_id = site_id
+      @list_id = list_id
+      @drive_id = drive_id
+    end
+
+    def post_to_ms_list(submission)
+      uri = URI.parse("#{root_graph_url}/sites/#{site_id}/lists/#{list_id}")
+
+      @connection ||= Faraday.new(uri) do |conn|
+      end
+
+      response = @connection.post do |req|
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Authorization'] = "Bearer #{get_auth_token}"
+        req.body = ms_list_payload(submission)
+      end
+
+      JSON.parse(response.body)
+    end
+
+    def send_attachment_to_drive(attachment)
+      uri = URI.parse("#{root_graph_url}/sites/#{site_id}/drive/items/#{drive_id}:/#{attachment.filename}:/content")
+
+      @connection ||= Faraday.new(uri) do |conn|
+      end
+
+      response = @connection.post do |req|
+        req.headers['Content-Type'] = 'text/plain'
+        req.headers['Authorization'] = "Bearer #{get_auth_token}"
+        req.body = attachment
+      end
+
+      JSON.parse(response.body)
+    end
+
+    def get_auth_token
+      response = auth_connection.post do |req|
+        req.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        req.body = URI.encode_www_form(form_data)
+      end
+
+      response_body = JSON.parse(response.body)
+
+      response_body['access_token']
+    end
+
+    def ms_list_payload(submission)
+      submission.to_json
+    end
+
+    private
+
+    def auth_connection
+      @auth_connection ||= Faraday.new(URI.parse(auth_url)) do |conn|
+        conn.response :raise_error
+        conn.request :multipart
+        conn.request :url_encoded
+        conn.adapter :net_http
+      end
+    end
+
+    def form_data
+      {
+        client_id: admin_app,
+        client_secret: admin_secret,
+        grant_type: 'client_credentials',
+        resource: 'https://graph.microsoft.com/'
+      }
+    end
+
+    def admin_app
+      ENV['MS_ADMIN_APP_ID']
+    end
+
+    def admin_secret
+      ENV['MS_ADMIN_APP_SECRET']
+    end
+
+    def auth_url
+      ENV['MS_OAUTH_URL']
+    end
+  end
+end

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -17,10 +17,7 @@ module V2
       @connection ||= Faraday.new(uri) do |conn|
       end
 
-      Rails.logger.info('=============')
-      Rails.logger.info('sending payload')
       answers_payload = ms_list_payload(submission, id)
-      Rails.logger.info(answers_payload)
 
       response = @connection.post do |req|
         req.headers['Content-Type'] = 'application/json'
@@ -28,10 +25,7 @@ module V2
         req.body = { 'fields' => answers_payload }.to_json
       end
 
-      parsed_response = JSON.parse(response.body)
-      Rails.logger.info(parsed_response)
-
-      parsed_response
+      JSON.parse(response.body)
     end
 
     def create_folder_in_drive(submission_id)
@@ -63,25 +57,15 @@ module V2
       connection = Faraday.new(uri) do |conn|
       end
 
-      Rails.logger.info('=============')
-      Rails.logger.info('sending file to')
       Rails.logger.info("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{filename}:/content")
-
+      # byebug
       response = connection.put do |req|
         req.headers['Content-Type'] = 'text/plain'
         req.headers['Authorization'] = "Bearer #{get_auth_token}"
         req.body = File.read(attachment.path)
       end
 
-      parsed_response = JSON.parse(response.body)
-      Rails.logger.info('=============')
-      Rails.logger.info(response)
-      Rails.logger.info(response.status)
-      Rails.logger.info('=============')
-      Rails.logger.info(parsed_response)
-      Rails.logger.info('=============')
-
-      parsed_response
+      JSON.parse(response.body)
     end
 
     def get_auth_token
@@ -96,8 +80,6 @@ module V2
     end
 
     def ms_list_payload(submission, id)
-      # submission.to_json
-
       new_data = {
         'fields' => {
           'Title' => id

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -39,12 +39,8 @@ module V2
       end
 
       Rails.logger.info('=============')
-      Rails.logger.info('sending file')
-      Rails.logger.info(attachment)
-      Rails.logger.info('=============')
-      Rails.logger.info('to drive')
-      Rails.logger.info(drive_id)
-      Rails.logger.info('=============')
+      Rails.logger.info('sending file to')
+      Rails.logger.info("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{filename}:/content")
 
       response = @connection.post do |req|
         req.headers['Content-Type'] = 'text/plain'

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module V2
   class SendToMsGraphService
     attr_accessor :site_id, :list_id, :drive_id, :root_graph_url
@@ -38,7 +40,7 @@ module V2
     end
 
     def send_attachment_to_drive(attachment)
-      uri = URI.parse(URI::encode("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{attachment.filename}:/content"))
+      uri = URI.parse(CGI.escape("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{attachment.filename}:/content"))
 
       @connection ||= Faraday.new(uri) do |conn|
       end

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -38,7 +38,7 @@ module V2
     end
 
     def send_attachment_to_drive(attachment)
-      uri = URI.parse("#{root_graph_url}/sites/#{site_id}/drive/items/#{drive_id}:/#{attachment.filename}:/content")
+      uri = URI.parse("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{attachment.filename}:/content")
 
       @connection ||= Faraday.new(uri) do |conn|
       end

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -86,7 +86,7 @@ module V2
 
       submission['pages'].each do |page|
         page['answers'].each do |answer|
-          value = answer['answer'].is_a?(Hash) ? answer['answer'].to_json : answer['answer']
+          value = answer['answer'].is_a?(Hash) ? answer_from_hash(answer) : answer['answer']
           keystring = answer['field_id'].to_s
           colname = Digest::MD5.hexdigest(keystring).tr('0-9', '')
           merge_data << { colname => value }
@@ -100,6 +100,10 @@ module V2
       end
 
       new_data['fields'].merge!(result_hash)
+    end
+
+    def answer_from_hash(answer)
+      answer.map { |_k, v| v }.join('; ')
     end
 
     private

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -38,7 +38,7 @@ module V2
     end
 
     def send_attachment_to_drive(attachment)
-      uri = URI.parse("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{attachment.filename}:/content")
+      uri = URI.parse(URI::encode("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{attachment.filename}:/content"))
 
       @connection ||= Faraday.new(uri) do |conn|
       end

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -18,9 +18,6 @@ module V2
       end
 
       payload = ms_list_payload(submission, id)
-      Rails.logger.info('=============')
-      Rails.logger.info('sending this payload:')
-      Rails.logger.info(payload)
 
       response = @connection.post do |req|
         req.headers['Content-Type'] = 'application/json'
@@ -29,12 +26,7 @@ module V2
       end
 
       parsed_response = JSON.parse(response.body)
-      Rails.logger.info('=============')
-      Rails.logger.info(response)
-      Rails.logger.info(response.status)
-      Rails.logger.info('=============')
       Rails.logger.info(parsed_response)
-      Rails.logger.info('=============')
 
       parsed_response
     end
@@ -46,6 +38,14 @@ module V2
       @connection ||= Faraday.new(uri) do |conn|
       end
 
+      Rails.logger.info('=============')
+      Rails.logger.info('sending file')
+      Rails.logger.info(attachment)
+      Rails.logger.info('=============')
+      Rails.logger.info('to drive')
+      Rails.logger.info(drive_id)
+      Rails.logger.info('=============')
+
       response = @connection.post do |req|
         req.headers['Content-Type'] = 'text/plain'
         req.headers['Authorization'] = "Bearer #{get_auth_token}"
@@ -53,7 +53,12 @@ module V2
       end
 
       parsed_response = JSON.parse(response.body)
+      Rails.logger.info('=============')
+      Rails.logger.info(response)
+      Rails.logger.info(response.status)
+      Rails.logger.info('=============')
       Rails.logger.info(parsed_response)
+      Rails.logger.info('=============')
 
       parsed_response
     end

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -34,9 +34,31 @@ module V2
       parsed_response
     end
 
-    def send_attachment_to_drive(attachment, id)
+    def create_folder_in_drive(submission_id)
+      drive_name = CGI.escape("#{submission_id}-attachments")
+
+      uri = URI.parse("#{root_graph_url}/sites/#{site_id}/drive/items/#{drive_id}/children")
+
+      connection ||= Faraday.new(uri) do |conn|
+      end
+
+      body = {
+        'name' => drive_name,
+        'folder' => {}
+      }
+
+      response = connection.post do |req|
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Authorization'] = "Bearer #{get_auth_token}"
+        req.body = body.to_json
+      end
+
+      response.status == 201 ? JSON.parse(response.body)['id'] : drive_id
+    end
+
+    def send_attachment_to_drive(attachment, id, folder)
       filename = CGI.escape("#{id}-#{attachment.filename}")
-      uri = URI.parse("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{filename}:/content")
+      uri = URI.parse("#{root_graph_url}sites/#{site_id}/drive/items/#{folder}:/#{filename}:/content")
 
       connection = Faraday.new(uri) do |conn|
       end

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -2,11 +2,11 @@ module V2
   class SendToMsGraphService
     attr_accessor :site_id, :list_id, :drive_id, :root_graph_url
 
-    def initialize(root_graph_url: ENV['MS_GRAPH_ROOT_URL'], site_id: ENV['MS_SITE_ID'], list_id: ENV['MS_LIST_ID'], drive_id: ENV['MS_DRIVE_ID'])
-      @root_graph_url = root_graph_url
-      @site_id = site_id
-      @list_id = list_id
-      @drive_id = drive_id
+    def initialize(action)
+      @root_graph_url = action['graph_url']
+      @site_id = action['site_id']
+      @list_id = action['list_id']
+      @drive_id = action['drive_id']
     end
 
     def post_to_ms_list(submission)

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -86,10 +86,10 @@ module V2
 
       submission['pages'].each do |page|
         page['answers'].each do |answer|
+          value = answer['answer'].is_a?(Hash) ? answer['answer'].to_json : answer['answer']
           keystring = answer['field_id'].to_s
-          md5name = Digest::MD5.hexdigest keystring
-          md5stripped = md5name.tr('0-9', '')
-          merge_data << { md5stripped => answer['answer'] }
+          colname = Digest::MD5.hexdigest(keystring).tr('0-9', '')
+          merge_data << { colname => value }
         end
       end
 
@@ -99,7 +99,7 @@ module V2
         result_hash.merge!(hash)
       end
 
-      new_data['fields'].merge!(result_hash.to_s)
+      new_data['fields'].merge!(result_hash)
     end
 
     private

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -21,7 +21,10 @@ module V2
         req.body = ms_list_payload(submission)
       end
 
-      JSON.parse(response.body)
+      parsed_response = JSON.parse(response.body)
+      Rails.logger.info(parsed_response)
+
+      parsed_response
     end
 
     def send_attachment_to_drive(attachment)
@@ -36,7 +39,10 @@ module V2
         req.body = attachment
       end
 
-      JSON.parse(response.body)
+      parsed_response = JSON.parse(response.body)
+      Rails.logger.info(parsed_response)
+
+      parsed_response
     end
 
     def get_auth_token

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -23,7 +23,7 @@ module V2
       response = @connection.post do |req|
         req.headers['Content-Type'] = 'application/json'
         req.headers['Authorization'] = "Bearer #{get_auth_token}"
-        req.body = payload
+        req.body = payload.to_json
       end
 
       parsed_response = JSON.parse(response.body)
@@ -92,7 +92,7 @@ module V2
         result_hash.merge!(hash)
       end
 
-      new_data['fields'].merge!(result_hash).to_json
+      new_data['fields'].merge!(result_hash)
     end
 
     private

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -49,7 +49,7 @@ module V2
       response = @connection.post do |req|
         req.headers['Content-Type'] = 'text/plain'
         req.headers['Authorization'] = "Bearer #{get_auth_token}"
-        req.body = File.read(attachment.file)
+        req.body = File.read(attachment.path)
       end
 
       parsed_response = JSON.parse(response.body)

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -1,7 +1,7 @@
 module V2
   class SendToMsGraphService
     attr_accessor :site_id, :list_id, :drive_id, :root_graph_url
-    
+
     def initialize(root_graph_url: ENV['MS_GRAPH_ROOT_URL'], site_id: ENV['MS_SITE_ID'], list_id: ENV['MS_LIST_ID'], drive_id: ENV['MS_DRIVE_ID'])
       @root_graph_url = root_graph_url
       @site_id = site_id

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -34,8 +34,8 @@ module V2
       parsed_response
     end
 
-    def send_attachment_to_drive(attachment)
-      filename = CGI.escape(attachment.filename)
+    def send_attachment_to_drive(attachment, id)
+      filename = CGI.escape("#{id}-#{attachment.filename}")
       uri = URI.parse("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{filename}:/content")
 
       connection = Faraday.new(uri) do |conn|

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -42,7 +42,7 @@ module V2
       Rails.logger.info('sending file to')
       Rails.logger.info("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{filename}:/content")
 
-      response = @connection.post do |req|
+      response = @connection.put do |req|
         req.headers['Content-Type'] = 'text/plain'
         req.headers['Authorization'] = "Bearer #{get_auth_token}"
         req.body = File.read(attachment.path)

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -17,12 +17,15 @@ module V2
       @connection ||= Faraday.new(uri) do |conn|
       end
 
-      payload = ms_list_payload(submission, id)
+      Rails.logger.info('=============')
+      Rails.logger.info('sending payload')
+      answers_payload = ms_list_payload(submission, id)
+      Rails.logger.info(answers_payload)
 
       response = @connection.post do |req|
         req.headers['Content-Type'] = 'application/json'
         req.headers['Authorization'] = "Bearer #{get_auth_token}"
-        req.body = { 'fields' => payload }.to_json
+        req.body = { 'fields' => answers_payload }.to_json
       end
 
       parsed_response = JSON.parse(response.body)

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -10,7 +10,7 @@ module V2
     end
 
     def post_to_ms_list(submission, id)
-      uri = URI.parse("#{root_graph_url}/sites/#{site_id}/lists/#{list_id}")
+      uri = URI.parse("#{root_graph_url}/sites/#{site_id}/lists/#{list_id}/items")
 
       @connection ||= Faraday.new(uri) do |conn|
       end

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -23,7 +23,7 @@ module V2
       response = @connection.post do |req|
         req.headers['Content-Type'] = 'application/json'
         req.headers['Authorization'] = "Bearer #{get_auth_token}"
-        req.body = payload.to_json
+        req.body = { 'fields' => payload }.to_json
       end
 
       parsed_response = JSON.parse(response.body)

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -22,7 +22,11 @@ module V2
       end
 
       parsed_response = JSON.parse(response.body)
+      Rails.logger.info('=============')
+      Rails.logger.info(response)
+      Rails.logger.info('=============')
       Rails.logger.info(parsed_response)
+      Rails.logger.info('=============')
 
       parsed_response
     end

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -29,6 +29,7 @@ module V2
       parsed_response = JSON.parse(response.body)
       Rails.logger.info('=============')
       Rails.logger.info(response)
+      Rails.logger.info(response.status)
       Rails.logger.info('=============')
       Rails.logger.info(parsed_response)
       Rails.logger.info('=============')

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -38,14 +38,14 @@ module V2
       filename = CGI.escape(attachment.filename)
       uri = URI.parse("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{filename}:/content")
 
-      @connection ||= Faraday.new(uri) do |conn|
+      connection = Faraday.new(uri) do |conn|
       end
 
       Rails.logger.info('=============')
       Rails.logger.info('sending file to')
       Rails.logger.info("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{filename}:/content")
 
-      response = @connection.put do |req|
+      response = connection.put do |req|
         req.headers['Content-Type'] = 'text/plain'
         req.headers['Authorization'] = "Bearer #{get_auth_token}"
         req.body = File.read(attachment.path)
@@ -99,7 +99,7 @@ module V2
         result_hash.merge!(hash)
       end
 
-      new_data['fields'].merge!(result_hash.to_json)
+      new_data['fields'].merge!(result_hash.to_s)
     end
 
     private

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -40,7 +40,8 @@ module V2
     end
 
     def send_attachment_to_drive(attachment)
-      uri = URI.parse(CGI.escape("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{attachment.filename}:/content"))
+      filename = CGI.escape(attachment.filename)
+      uri = URI.parse("#{root_graph_url}sites/#{site_id}/drive/items/#{drive_id}:/#{filename}:/content")
 
       @connection ||= Faraday.new(uri) do |conn|
       end

--- a/deploy-eks/fb-submitter-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-submitter-chart/templates/deployment.yaml
@@ -97,6 +97,7 @@ spec:
               secretKeyRef:
                 name: fb-submitter-app-secrets-{{ .Values.environmentName }}
                 key: submission_decryption_key
+
       volumes:
         - name: tmp-files
           emptyDir: {}
@@ -188,6 +189,21 @@ spec:
               secretKeyRef:
                 name: fb-submitter-app-secrets-{{ .Values.environmentName }}
                 key: submission_decryption_key
+          - name: MS_ADMIN_APP_ID
+            valueFrom:
+              secretKeyRef:
+                name: fb-submitter-app-secrets-{{ .Values.environmentName }}
+                key: ms_admin_app_id
+          - name: MS_ADMIN_APP_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: fb-submitter-app-secrets-{{ .Values.environmentName }}
+                key: ms_admin_app_secret
+          - name: MS_OAUTH_URL
+            valueFrom:
+              secretKeyRef:
+                name: fb-submitter-app-secrets-{{ .Values.environmentName }}
+                key: ms_oauth_url
       volumes:
         - name: tmp-files
           emptyDir: {}

--- a/deploy-eks/fb-submitter-chart/templates/secrets.yaml
+++ b/deploy-eks/fb-submitter-chart/templates/secrets.yaml
@@ -18,3 +18,6 @@ data:
   encryption_key: {{ .Values.encryption_key }}
   encryption_salt: {{ .Values.encryption_salt }}
   submission_decryption_key: {{ .Values.submission_decryption_key }}
+  ms_oauth_url: {{ .Values.ms_oauth_url }}
+  ms_admin_app_id: {{ .Values.ms_admin_app_id }}
+  ms_admin_app_secret: {{ .Values.ms_admin_app_secret }}

--- a/schemas/submission_payload.json
+++ b/schemas/submission_payload.json
@@ -69,7 +69,8 @@
           "enum": [
             "csv",
             "email",
-            "json"
+            "json",
+            "mslist"
           ]
         },
         "variant": {
@@ -109,6 +110,18 @@
         },
         "key": {
           "type": "string"
+        },
+        "graph_url": {
+          "type": "string"
+        },
+        "site_id": {
+          "type": "string"
+        },
+        "list_id": {
+          "type": "string"
+        },
+        "drive_id": {
+          "type": "string"
         }
       },
       "anyOf":[
@@ -123,6 +136,13 @@
             "to",
             "from",
             "include_pdf"
+          ]
+        },
+        {
+          "required": [
+            "site_id",
+            "list_id",
+            "graph_url"
           ]
         }
       ],

--- a/spec/fixtures/payloads/valid_submission.json
+++ b/spec/fixtures/payloads/valid_submission.json
@@ -35,6 +35,15 @@
       "url": "http://api-endpoint.com",
       "key": "fb730a667840d79c",
       "include_attachments": false
+    },
+    {
+      "kind": "mslist",
+      "variant": null,
+      "graph_url": "graph-url.microsoft.com",
+      "site_id": "1234",
+      "list_id": "5678",
+      "drive_id": "root",
+      "include_attachments": true
     }
   ],
   "pages": [

--- a/spec/jobs/v2/process_submission_job_spec.rb
+++ b/spec/jobs/v2/process_submission_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe V2::ProcessSubmissionJob do
                    Rails.root.join('spec/fixtures/payloads/pdf_generator.json')
                  )).merge('submission_id' => submission.id)
     end
-    let(:email_output_service) { instance_spy(EmailOutputServiceV2) }
+    let(:email_output_service) { instance_spy(EmailOutputService) }
     let(:ms_graph_service) { instance_spy(V2::SendToMsGraphService) }
     let(:generated_pdf_content) do
       "I'm one with the Force. The Force is with me.\n"
@@ -33,7 +33,7 @@ RSpec.describe V2::ProcessSubmissionJob do
     before do
       allow(ENV).to receive(:[])
       allow(ENV).to receive(:[]).with('SUBMISSION_DECRYPTION_KEY').and_return(key)
-      allow(EmailOutputServiceV2).to receive(:new).and_return(email_output_service)
+      allow(EmailOutputService).to receive(:new).and_return(email_output_service)
       allow(V2::SendToMsGraphService).to receive(:new).and_return(ms_graph_service)
     end
 
@@ -204,7 +204,7 @@ RSpec.describe V2::ProcessSubmissionJob do
         'jar-jar-binks'
       end
       let(:action) { fixture['actions'].select { |action| action['kind'] == 'mslist' }.first }
-      let(:encrypted_payload) do      
+      let(:encrypted_payload) do
         fixture['actions'] = fixture['actions'].select { |action| action['kind'] == 'mslist' }
         SubmissionEncryption.new(key:).encrypt(fixture)
       end
@@ -221,11 +221,11 @@ RSpec.describe V2::ProcessSubmissionJob do
             .to_return(status: 200, body: 'image', headers: {})
 
           # post to graph api stub
-          stub_request(:post, "https://rooturl.graph.example.com/sites/site_id/drive/items/root:/basset-hound-dog-picture.png:/content")
+          stub_request(:post, 'https://rooturl.graph.example.com/sites/site_id/drive/items/root:/basset-hound-dog-picture.png:/content')
             .to_return(status: 200, body: response.to_json, headers: {})
 
           # post to list
-          stub_request(:post, "https://rooturl.graph.example.com/sites/site_id/lists/list_id")
+          stub_request(:post, 'https://rooturl.graph.example.com/sites/site_id/lists/list_id')
             .to_return(status: 200, body: response.to_json, headers: {})
 
           # auth url call
@@ -239,12 +239,12 @@ RSpec.describe V2::ProcessSubmissionJob do
           allow(ENV).to receive(:[]).with('MS_GRAPH_ROOT_URL').and_return('https://rooturl.graph.example.com')
           allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
           allow(ENV).to receive(:[]).with('SUBMISSION_DECRYPTION_KEY').and_return(key)
-          allow(EmailOutputServiceV2).to receive(:new).and_return(email_output_service)
+          allow(EmailOutputService).to receive(:new).and_return(email_output_service)
         end
 
         it 'sends to graph api then attachments to drive api' do
           perform_job
-  
+
           expect(ms_graph_service).to have_received(:post_to_ms_list) do |args|
             expect(args[:submission]).to eq(submission)
           end
@@ -253,7 +253,6 @@ RSpec.describe V2::ProcessSubmissionJob do
             expect(args.filename).to match(/basset-hound-dog-picture.png/)
           end
         end
-
       end
     end
 

--- a/spec/jobs/v2/process_submission_job_spec.rb
+++ b/spec/jobs/v2/process_submission_job_spec.rb
@@ -245,12 +245,12 @@ RSpec.describe V2::ProcessSubmissionJob do
         it 'sends to graph api then attachments to drive api' do
           perform_job
 
-          expect(ms_graph_service).to have_received(:post_to_ms_list) do |args|
-            expect(args[:submission]).to eq(submission)
-          end
-
           expect(ms_graph_service).to have_received(:send_attachment_to_drive) do |args|
             expect(args.filename).to match(/basset-hound-dog-picture.png/)
+          end
+
+          expect(ms_graph_service).to have_received(:post_to_ms_list) do |args|
+            expect(args['submission_id']).to eq(submission.id)
           end
         end
       end

--- a/spec/jobs/v2/process_submission_job_spec.rb
+++ b/spec/jobs/v2/process_submission_job_spec.rb
@@ -233,11 +233,11 @@ RSpec.describe V2::ProcessSubmissionJob do
             .to_return(status: 200, body: { 'access_token' => 'valid_token' }.to_json, headers: {})
 
           allow(ENV).to receive(:[])
-          allow(ENV).to receive(:[]).with('MS_SITE_ID').and_return('site_id')
-          allow(ENV).to receive(:[]).with('MS_DRIVE_ID').and_return('root')
-          allow(ENV).to receive(:[]).with('MS_LIST_ID').and_return('list_id')
-          allow(ENV).to receive(:[]).with('MS_GRAPH_ROOT_URL').and_return('https://rooturl.graph.example.com')
-          allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
+          # allow(ENV).to receive(:[]).with('MS_SITE_ID').and_return('site_id')
+          # allow(ENV).to receive(:[]).with('MS_DRIVE_ID').and_return('root')
+          # allow(ENV).to receive(:[]).with('MS_LIST_ID').and_return('list_id')
+          # allow(ENV).to receive(:[]).with('MS_GRAPH_ROOT_URL').and_return('https://rooturl.graph.example.com')
+          # allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
           allow(ENV).to receive(:[]).with('SUBMISSION_DECRYPTION_KEY').and_return(key)
           allow(EmailOutputService).to receive(:new).and_return(email_output_service)
         end

--- a/spec/jobs/v2/process_submission_job_spec.rb
+++ b/spec/jobs/v2/process_submission_job_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe V2::ProcessSubmissionJob do
                    Rails.root.join('spec/fixtures/payloads/pdf_generator.json')
                  )).merge('submission_id' => submission.id)
     end
-    let(:email_output_service) { instance_spy(EmailOutputService) }
+    let(:email_output_service) { instance_spy(EmailOutputServiceV2) }
+    let(:ms_graph_service) { instance_spy(V2::SendToMsGraphService) }
     let(:generated_pdf_content) do
       "I'm one with the Force. The Force is with me.\n"
     end
@@ -32,7 +33,8 @@ RSpec.describe V2::ProcessSubmissionJob do
     before do
       allow(ENV).to receive(:[])
       allow(ENV).to receive(:[]).with('SUBMISSION_DECRYPTION_KEY').and_return(key)
-      allow(EmailOutputService).to receive(:new).and_return(email_output_service)
+      allow(EmailOutputServiceV2).to receive(:new).and_return(email_output_service)
+      allow(V2::SendToMsGraphService).to receive(:new).and_return(ms_graph_service)
     end
 
     context 'when email action' do
@@ -186,6 +188,72 @@ RSpec.describe V2::ProcessSubmissionJob do
         expect(email_output_service).to have_received(:execute) do |args|
           expect(args[:pdf_attachment]).to be_nil
         end
+      end
+    end
+
+    context 'when microsoft graph api action' do
+      let(:key) { SecureRandom.uuid[0..31] }
+      let(:submission) do
+        create(:submission, payload: encrypted_payload, access_token:)
+      end
+      let(:fixture) { payload_fixture }
+      let(:payload_fixture) do
+        JSON.parse(File.read(Rails.root.join('spec/fixtures/payloads/valid_submission.json')))
+      end
+      let(:access_token) do
+        'jar-jar-binks'
+      end
+      let(:action) { fixture['actions'].select { |action| action['kind'] == 'mslist' }.first }
+      let(:encrypted_payload) do      
+        fixture['actions'] = fixture['actions'].select { |action| action['kind'] == 'mslist' }
+        SubmissionEncryption.new(key:).encrypt(fixture)
+      end
+      let(:response) do
+        {
+          webUrl: 'i_am_the_drive_url'
+        }
+      end
+
+      context 'when including attachments' do
+        before do
+          # download attachment stub
+          stub_request(:get, 'http://fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/dog-contest/user/1/123')
+            .to_return(status: 200, body: 'image', headers: {})
+
+          # post to graph api stub
+          stub_request(:post, "https://rooturl.graph.example.com/sites/site_id/drive/items/root:/basset-hound-dog-picture.png:/content")
+            .to_return(status: 200, body: response.to_json, headers: {})
+
+          # post to list
+          stub_request(:post, "https://rooturl.graph.example.com/sites/site_id/lists/list_id")
+            .to_return(status: 200, body: response.to_json, headers: {})
+
+          # auth url call
+          stub_request(:post, 'https://authurl.example.com')
+            .to_return(status: 200, body: { 'access_token' => 'valid_token' }.to_json, headers: {})
+
+          allow(ENV).to receive(:[])
+          allow(ENV).to receive(:[]).with('MS_SITE_ID').and_return('site_id')
+          allow(ENV).to receive(:[]).with('MS_DRIVE_ID').and_return('root')
+          allow(ENV).to receive(:[]).with('MS_LIST_ID').and_return('list_id')
+          allow(ENV).to receive(:[]).with('MS_GRAPH_ROOT_URL').and_return('https://rooturl.graph.example.com')
+          allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
+          allow(ENV).to receive(:[]).with('SUBMISSION_DECRYPTION_KEY').and_return(key)
+          allow(EmailOutputServiceV2).to receive(:new).and_return(email_output_service)
+        end
+
+        it 'sends to graph api then attachments to drive api' do
+          perform_job
+  
+          expect(ms_graph_service).to have_received(:post_to_ms_list) do |args|
+            expect(args[:submission]).to eq(submission)
+          end
+
+          expect(ms_graph_service).to have_received(:send_attachment_to_drive) do |args|
+            expect(args.filename).to match(/basset-hound-dog-picture.png/)
+          end
+        end
+
       end
     end
 

--- a/spec/services/adapters/jwe_webhook_destination_spec.rb
+++ b/spec/services/adapters/jwe_webhook_destination_spec.rb
@@ -32,7 +32,6 @@ describe Adapters::JweWebhookDestination do
     expect(WebMock).to have_requested(:post, expected_url).once
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it 'sends JWE encrypted payload' do
     allow(Typhoeus::Request).to receive(:new) do |url, hash|
       expect(url).to eql(expected_url)
@@ -42,7 +41,6 @@ describe Adapters::JweWebhookDestination do
 
     adapter.send_webhook(body: payload)
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'throws exception if not 200 response' do
     stub_request(:post, expected_url).to_return(status: 500)

--- a/spec/services/attachment_generator_spec.rb
+++ b/spec/services/attachment_generator_spec.rb
@@ -22,7 +22,6 @@ describe AttachmentGenerator do
     allow(pdf_attachment).to receive(:size).and_return(7777)
   end
 
-  # rubocop:disable RSpec/ExampleLength
   context 'when no attachments or pdfs are required' do
     it 'does not sort any attachments' do
       subject.execute(action: {}, attachments: [upload1, upload2], pdf_attachment:)

--- a/spec/services/email_output_service_spec.rb
+++ b/spec/services/email_output_service_spec.rb
@@ -153,7 +153,6 @@ RSpec.describe EmailOutputService do
     end
   end
 
-  # rubocop:disable RSpec/ExampleLength
   context 'when email sending fails' do
     let(:include_attachments) { true }
     let(:first_email_attachments) { [upload1, upload2] }

--- a/spec/services/v2/send_to_ms_graph_service_spec.rb
+++ b/spec/services/v2/send_to_ms_graph_service_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe V2::SendToMsGraphService do
   end
   let(:action) { payload['actions'][0].to_json }
 
-  context 'create a folder' do
-    context 'successfully' do
+  context 'when creating a folder for this submission' do
+    context 'when successful' do
       before do
         stub_request(:post, 'https://graph-url.microsoft.com/sites/1234/drive/items/root/children')
         .to_return(status: 201, body: { id: 'a-folder' }.to_json, headers: {})
@@ -104,7 +104,7 @@ RSpec.describe V2::SendToMsGraphService do
       end
     end
 
-    context 'api error' do
+    context 'when api responds with error' do
       before do
         stub_request(:post, 'https://graph-url.microsoft.com/sites/1234/drive/items/root/children')
         .to_return(status: 500, body: {}.to_json, headers: {})
@@ -123,8 +123,8 @@ RSpec.describe V2::SendToMsGraphService do
     end
   end
 
-  context 'get auth token' do
-    context 'success' do
+  context 'when authenticating' do
+    context 'when successful' do
       before do
         stub_request(:post, 'https://graph-url.microsoft.com/sites/1234/drive/items/root/children')
         .to_return(status: 500, body: {}.to_json, headers: {})
@@ -148,11 +148,11 @@ RSpec.describe V2::SendToMsGraphService do
       end
 
       it 'calls the api with the form and return the value' do
-        expect(subject.get_auth_token).to eq('valid_token')
+        expect(graph_service.get_auth_token).to eq('valid_token')
       end
     end
 
-    context 'api error' do
+    context 'when api responds with error' do
       before do
         stub_request(:post, 'https://graph-url.microsoft.com/sites/1234/drive/items/root/children')
         .to_return(status: 500, body: {}.to_json, headers: {})
@@ -176,11 +176,11 @@ RSpec.describe V2::SendToMsGraphService do
       end
 
       it 'calls the api with the form and return the value' do
-        expect { subject.get_auth_token }.to raise_error(Faraday::ServerError)
+        expect { graph_service.get_auth_token }.to raise_error(Faraday::ServerError)
       end
     end
 
-    context 'permission denied' do
+    context 'when permission denied' do
       before do
         stub_request(:post, 'https://graph-url.microsoft.com/sites/1234/drive/items/root/children')
         .to_return(status: 500, body: {}.to_json, headers: {})
@@ -204,12 +204,12 @@ RSpec.describe V2::SendToMsGraphService do
       end
 
       it 'calls the api with the form and return the value' do
-        expect { subject.get_auth_token }.to raise_error(Faraday::ForbiddenError)
+        expect { graph_service.get_auth_token }.to raise_error(Faraday::ForbiddenError)
       end
     end
   end
 
-  context 'send attachment to drive' do
+  context 'when sending attachment to drive' do
     let(:response) do
       {
         'webUrl' => 'file_in_drive'
@@ -217,7 +217,7 @@ RSpec.describe V2::SendToMsGraphService do
     end
     let(:attachment) { instance_spy(Attachment) }
 
-    context 'successfully' do
+    context 'when successful' do
       before do
         stub_request(:put, "https://graph-url.microsoft.comsites/1234/drive/items/folder_path:/#{submission_id}-filename.png:/content")
           .with(
@@ -249,8 +249,8 @@ RSpec.describe V2::SendToMsGraphService do
     end
   end
 
-  context 'send answers to list' do
-    context 'successfully' do
+  context 'when sending answers to list' do
+    context 'when successful' do
       let(:response) do
         {
           'list_updated' => 'today'

--- a/spec/services/v2/send_to_ms_graph_service_spec.rb
+++ b/spec/services/v2/send_to_ms_graph_service_spec.rb
@@ -219,17 +219,18 @@ RSpec.describe V2::SendToMsGraphService do
 
     context 'successfully' do
       before do
-        stub_request(:put, "https://graph-url.microsoft.comsites/1234/drive/items/folder_path:/#{submission_id}-filename.png:/content").
-          with(
+        stub_request(:put, "https://graph-url.microsoft.comsites/1234/drive/items/folder_path:/#{submission_id}-filename.png:/content")
+          .with(
             body: "hello world\n",
             headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Bearer valid_token',
-          'Content-Type'=>'text/plain',
-          'User-Agent'=>'Faraday v1.10.3'
-            }).
-          to_return(status: 200, body: response.to_json, headers: {})
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => 'Bearer valid_token',
+              'Content-Type' => 'text/plain',
+              'User-Agent' => 'Faraday v1.10.3'
+            }
+          )
+          .to_return(status: 200, body: response.to_json, headers: {})
 
         stub_request(:post, 'https://authurl.example.com')
           .to_return(status: 200, body: { 'access_token' => 'valid_token' }.to_json, headers: {})
@@ -258,29 +259,30 @@ RSpec.describe V2::SendToMsGraphService do
 
       let(:answers_payload) do
         {
-          "fields"=>                                                               
+          'fields' =>
           {
-            "Title"=>submission_id,                       
-            "bfebbbeafabacdef"=>"Stormtrooper",                                    
-            "cbddedd"=>"FN-b0046eb3-37ff-400d-85f8-8bbb5c11183b",                  
-            "dddddbccfbd"=>"fb-acceptance-tests@digital.justice.gov.uk",           
-            "bebcdcfeeeda"=>"postal-address_address_1; Your postal address; {\"address_line_one\"=>\"1 road\", \"address_line_two\"=>\"\", \"city\"=>\"ruby town\", \"county\"=>\"\", \"postcode\"=>\"99 999\", \"country\"=>\"ruby land\"}"
+            'Title' => submission_id,
+            'bfebbbeafabacdef' => 'Stormtrooper',
+            'cbddedd' => 'FN-b0046eb3-37ff-400d-85f8-8bbb5c11183b',
+            'dddddbccfbd' => 'fb-acceptance-tests@digital.justice.gov.uk',
+            'bebcdcfeeeda' => 'postal-address_address_1; Your postal address; {"address_line_one"=>"1 road", "address_line_two"=>"", "city"=>"ruby town", "county"=>"", "postcode"=>"99 999", "country"=>"ruby land"}'
           }
         }
       end
 
       before do
-        stub_request(:post, "https://graph-url.microsoft.com/sites/1234/lists/5678/items").
-          with(
+        stub_request(:post, 'https://graph-url.microsoft.com/sites/1234/lists/5678/items')
+          .with(
             body: answers_payload.to_json,
             headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Bearer valid_token',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Faraday v1.10.3'
-            }).
-          to_return(status: 200, body: response.to_json, headers: {})
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => 'Bearer valid_token',
+              'Content-Type' => 'application/json',
+              'User-Agent' => 'Faraday v1.10.3'
+            }
+          )
+          .to_return(status: 200, body: response.to_json, headers: {})
 
         stub_request(:post, 'https://authurl.example.com')
           .to_return(status: 200, body: { 'access_token' => 'valid_token' }.to_json, headers: {})

--- a/spec/services/v2/send_to_ms_graph_service_spec.rb
+++ b/spec/services/v2/send_to_ms_graph_service_spec.rb
@@ -1,0 +1,298 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe V2::SendToMsGraphService do
+  subject(:graph_service) { described_class.new(JSON.parse(action)) }
+
+  let(:submission_id) { SecureRandom.uuid }
+  let(:submission_at) { Time.zone.now.iso8601(3) }
+  let(:payload) do
+    {
+      'submission_id' => submission_id,
+      'meta' => {
+        'pdf_heading' => 'Submission for new-runner-acceptance-tests',
+        'pdf_subheading' => 'Submission subheading for new-runner-acceptance-tests',
+        'submission_at' => submission_at
+      },
+      'service' => {
+        'id' => SecureRandom.uuid,
+        'slug' => 'new-runner-acceptance-tests',
+        'name' => 'new runner acceptance tests'
+      },
+      'actions' => [
+        {
+          "kind": 'mslist',
+          "variant": '',
+          "graph_url": 'https://graph-url.microsoft.com',
+          "site_id": '1234',
+          "list_id": '5678',
+          "drive_id": 'root',
+          "include_attachments": true
+        }
+      ],
+      'pages' => [
+        {
+          'heading' => 'Your name',
+          'answers' => [
+            {
+              'field_id' => 'name_text_1',
+              'field_name' => 'First name',
+              'answer' => 'Stormtrooper'
+            },
+            {
+              'field_id' => 'name_text_2',
+              'field_name' => 'Last name',
+              'answer' => 'FN-b0046eb3-37ff-400d-85f8-8bbb5c11183b'
+            }
+          ]
+        },
+        {
+          'heading' => '',
+          'answers' => [
+            {
+              'field_id' => 'your-email-address_text_1',
+              'field_name' => 'Your email address',
+              'answer' => 'fb-acceptance-tests@digital.justice.gov.uk'
+            }
+          ]
+        },
+        {
+          'heading' => '',
+          'answers' => [
+            {
+              'field_id' => 'postal-address_address_1',
+              'field_name' => 'Your postal address',
+              'answer' => {
+                'address_line_one' => '1 road',
+                'address_line_two' => '',
+                'city' => 'ruby town',
+                'county' => '',
+                'postcode' => '99 999',
+                'country' => 'ruby land'
+              }
+            }
+          ]
+        }
+      ],
+      'attachments' => [
+        {
+          'url ' => 'http://the-filestore-url-for-attachment',
+          'filename' => 'hello_world.txt',
+          'mimetype' => 'text/plain'
+        }
+      ]
+    }
+  end
+  let(:action) { payload['actions'][0].to_json }
+
+  context 'create a folder' do
+    context 'successfully' do
+      before do
+        stub_request(:post, 'https://graph-url.microsoft.com/sites/1234/drive/items/root/children')
+        .to_return(status: 201, body: { id: 'a-folder' }.to_json, headers: {})
+
+        stub_request(:post, 'https://authurl.example.com')
+          .to_return(status: 200, body: { 'access_token' => 'valid_token' }.to_json, headers: {})
+
+        allow(ENV).to receive(:[])
+
+        allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
+      end
+
+      it 'returns the drive id' do
+        expect(graph_service.create_folder_in_drive(submission_id)).to eq('a-folder')
+      end
+    end
+
+    context 'api error' do
+      before do
+        stub_request(:post, 'https://graph-url.microsoft.com/sites/1234/drive/items/root/children')
+        .to_return(status: 500, body: {}.to_json, headers: {})
+
+        stub_request(:post, 'https://authurl.example.com')
+          .to_return(status: 200, body: { 'access_token' => 'valid_token' }.to_json, headers: {})
+
+        allow(ENV).to receive(:[])
+
+        allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
+      end
+
+      it 'sends the error to sentry and defaults to the parent drive' do
+        expect(graph_service.create_folder_in_drive(submission_id)).to eq('root')
+      end
+    end
+  end
+
+  context 'get auth token' do
+    context 'success' do
+      before do
+        stub_request(:post, 'https://graph-url.microsoft.com/sites/1234/drive/items/root/children')
+        .to_return(status: 500, body: {}.to_json, headers: {})
+
+        stub_request(:post, 'https://authurl.example.com')
+          .with(
+            body: { 'client_id' => 'app_id', 'client_secret' => 'app_secret', 'grant_type' => 'client_credentials', 'resource' => 'https://graph.microsoft.com/' },
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Content-Type' => 'application/x-www-form-urlencoded',
+              'User-Agent' => 'Faraday v1.10.3'
+            }
+          ).to_return(status: 200, body: { 'access_token' => 'valid_token' }.to_json, headers: {})
+
+        allow(ENV).to receive(:[])
+
+        allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
+        allow(ENV).to receive(:[]).with('MS_ADMIN_APP_ID').and_return('app_id')
+        allow(ENV).to receive(:[]).with('MS_ADMIN_APP_SECRET').and_return('app_secret')
+      end
+
+      it 'calls the api with the form and return the value' do
+        expect(subject.get_auth_token).to eq('valid_token')
+      end
+    end
+
+    context 'api error' do
+      before do
+        stub_request(:post, 'https://graph-url.microsoft.com/sites/1234/drive/items/root/children')
+        .to_return(status: 500, body: {}.to_json, headers: {})
+
+        stub_request(:post, 'https://authurl.example.com')
+          .with(
+            body: { 'client_id' => 'app_id', 'client_secret' => 'app_secret', 'grant_type' => 'client_credentials', 'resource' => 'https://graph.microsoft.com/' },
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Content-Type' => 'application/x-www-form-urlencoded',
+              'User-Agent' => 'Faraday v1.10.3'
+            }
+          ).to_return(status: 500, body: {}.to_json, headers: {})
+
+        allow(ENV).to receive(:[])
+
+        allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
+        allow(ENV).to receive(:[]).with('MS_ADMIN_APP_ID').and_return('app_id')
+        allow(ENV).to receive(:[]).with('MS_ADMIN_APP_SECRET').and_return('app_secret')
+      end
+
+      it 'calls the api with the form and return the value' do
+        expect { subject.get_auth_token }.to raise_error(Faraday::ServerError)
+      end
+    end
+
+    context 'permission denied' do
+      before do
+        stub_request(:post, 'https://graph-url.microsoft.com/sites/1234/drive/items/root/children')
+        .to_return(status: 500, body: {}.to_json, headers: {})
+
+        stub_request(:post, 'https://authurl.example.com')
+          .with(
+            body: { 'client_id' => 'app_id', 'client_secret' => 'app_secret', 'grant_type' => 'client_credentials', 'resource' => 'https://graph.microsoft.com/' },
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Content-Type' => 'application/x-www-form-urlencoded',
+              'User-Agent' => 'Faraday v1.10.3'
+            }
+          ).to_return(status: 403, body: {}.to_json, headers: {})
+
+        allow(ENV).to receive(:[])
+
+        allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
+        allow(ENV).to receive(:[]).with('MS_ADMIN_APP_ID').and_return('app_id')
+        allow(ENV).to receive(:[]).with('MS_ADMIN_APP_SECRET').and_return('app_secret')
+      end
+
+      it 'calls the api with the form and return the value' do
+        expect { subject.get_auth_token }.to raise_error(Faraday::ForbiddenError)
+      end
+    end
+  end
+
+  context 'send attachment to drive' do
+    let(:response) do
+      {
+        'webUrl' => 'file_in_drive'
+      }
+    end
+    let(:attachment) { instance_spy(Attachment) }
+
+    context 'successfully' do
+      before do
+        stub_request(:put, "https://graph-url.microsoft.comsites/1234/drive/items/folder_path:/#{submission_id}-filename.png:/content").
+          with(
+            body: "hello world\n",
+            headers: {
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Authorization'=>'Bearer valid_token',
+          'Content-Type'=>'text/plain',
+          'User-Agent'=>'Faraday v1.10.3'
+            }).
+          to_return(status: 200, body: response.to_json, headers: {})
+
+        stub_request(:post, 'https://authurl.example.com')
+          .to_return(status: 200, body: { 'access_token' => 'valid_token' }.to_json, headers: {})
+
+        allow(ENV).to receive(:[])
+
+        allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
+
+        allow(attachment).to receive(:filename).and_return('filename.png')
+        allow(attachment).to receive(:path).and_return(Rails.root.join('spec/fixtures/files/hello_world.txt'))
+      end
+
+      it 'returns file info' do
+        expect(graph_service.send_attachment_to_drive(attachment, submission_id, 'folder_path')).to eq(response)
+      end
+    end
+  end
+
+  context 'send answers to list' do
+    context 'successfully' do
+      let(:response) do
+        {
+          'list_updated' => 'today'
+        }
+      end
+
+      let(:answers_payload) do
+        {
+          "fields"=>                                                               
+          {
+            "Title"=>submission_id,                       
+            "bfebbbeafabacdef"=>"Stormtrooper",                                    
+            "cbddedd"=>"FN-b0046eb3-37ff-400d-85f8-8bbb5c11183b",                  
+            "dddddbccfbd"=>"fb-acceptance-tests@digital.justice.gov.uk",           
+            "bebcdcfeeeda"=>"postal-address_address_1; Your postal address; {\"address_line_one\"=>\"1 road\", \"address_line_two\"=>\"\", \"city\"=>\"ruby town\", \"county\"=>\"\", \"postcode\"=>\"99 999\", \"country\"=>\"ruby land\"}"
+          }
+        }
+      end
+
+      before do
+        stub_request(:post, "https://graph-url.microsoft.com/sites/1234/lists/5678/items").
+          with(
+            body: answers_payload.to_json,
+            headers: {
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Authorization'=>'Bearer valid_token',
+          'Content-Type'=>'application/json',
+          'User-Agent'=>'Faraday v1.10.3'
+            }).
+          to_return(status: 200, body: response.to_json, headers: {})
+
+        stub_request(:post, 'https://authurl.example.com')
+          .to_return(status: 200, body: { 'access_token' => 'valid_token' }.to_json, headers: {})
+
+        allow(ENV).to receive(:[])
+
+        allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
+      end
+
+      it 'returns returns the api response' do
+        expect(graph_service.post_to_ms_list(payload, submission_id)).to eq(response)
+      end
+    end
+  end
+end

--- a/spec/services/v2/send_to_ms_graph_service_spec.rb
+++ b/spec/services/v2/send_to_ms_graph_service_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe V2::SendToMsGraphService do
         {
           'fields' =>
           {
-            'Title' => submission_id,
+            'debcefbcbdf' => submission_id,
             'bfebbbeafabacdef' => 'Stormtrooper',
             'cbddedd' => 'FN-b0046eb3-37ff-400d-85f8-8bbb5c11183b',
             'dddddbccfbd' => 'fb-acceptance-tests@digital.justice.gov.uk',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,7 +110,7 @@ SimpleCov.start do
   add_filter '/spec/'
 end
 
-# SimpleCov.minimum_coverage 100
+SimpleCov.minimum_coverage 100
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::Console

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,7 +110,7 @@ SimpleCov.start do
   add_filter '/spec/'
 end
 
-SimpleCov.minimum_coverage 100
+# SimpleCov.minimum_coverage 100
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::Console


### PR DESCRIPTION
When a submission includes the new kind of 'mslist', send the payload to the new adapter during the job.

Error handling is done in the same way as other actions - Faraday errors such as `Forbidden` or `Server Error` will cause the job to bounce back to the queue, otherwise mslists support 'patching' list items - any answer keys that don't match columns are silently dropped.

Document uploading is similarly done via pushing to sharepoint drives, and this can gracefully fail as well as throw and bounce the job, depending. Though each file is new and added to a new folder, so there is no expected fail case outside of network errors etc

Authentication to the MS tenancy is configured for the submitter via env vars, but the sharepoint site & list are expected to be configured per submission in the action payload. 

Deployed to dev an acceptance tests run
<img width="1713" alt="image" src="https://github.com/ministryofjustice/fb-submitter/assets/7647632/3dc82e11-dc69-405f-9f0b-29d2cd3e1f6c">


List submitted & with attachments in folder
![image (13)](https://github.com/ministryofjustice/fb-submitter/assets/7647632/6e0c3efc-ebb7-4b0d-9cde-cd0739187165)
![image (12)](https://github.com/ministryofjustice/fb-submitter/assets/7647632/86afe378-7256-4415-8449-96648d869b4a)
