### PR TITLE
Add links to file answers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,7 @@ workflows:
             branches:
               only:
                 - main
+                - update-file-link-answers
       - build_and_push_worker_image:
           context: *context
           requires:
@@ -268,6 +269,7 @@ workflows:
             branches:
               only:
                 - main
+                - update-file-link-answers
       - deploy_to_test_dev:
           context: *context
           requires:
@@ -283,24 +285,24 @@ workflows:
           requires:
             - deploy_to_test_dev
             - deploy_to_test_production
-      - deploy_to_live_dev:
-          context: *context
-          requires:
-            - acceptance_tests
-          filters:
-            branches:
-              only:
-                - main
-      - deploy_to_live_production:
-          context: *context
-          requires:
-            - acceptance_tests
-          filters:
-            branches:
-              only:
-                - main
-      - smoke_tests:
-          context: *context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+      # - deploy_to_live_dev:
+      #     context: *context
+      #     requires:
+      #       - acceptance_tests
+      #     filters:
+      #       branches:
+      #         only:
+      #           - main
+      # - deploy_to_live_production:
+      #     context: *context
+      #     requires:
+      #       - acceptance_tests
+      #     filters:
+      #       branches:
+      #         only:
+      #           - main
+      # - smoke_tests:
+      #     context: *context
+      #     requires:
+      #       - deploy_to_live_dev
+      #       - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,6 @@ workflows:
             branches:
               only:
                 - main
-                - update-file-link-answers
       - build_and_push_worker_image:
           context: *context
           requires:
@@ -269,7 +268,6 @@ workflows:
             branches:
               only:
                 - main
-                - update-file-link-answers
       - deploy_to_test_dev:
           context: *context
           requires:
@@ -285,24 +283,24 @@ workflows:
           requires:
             - deploy_to_test_dev
             - deploy_to_test_production
-      # - deploy_to_live_dev:
-      #     context: *context
-      #     requires:
-      #       - acceptance_tests
-      #     filters:
-      #       branches:
-      #         only:
-      #           - main
-      # - deploy_to_live_production:
-      #     context: *context
-      #     requires:
-      #       - acceptance_tests
-      #     filters:
-      #       branches:
-      #         only:
-      #           - main
-      # - smoke_tests:
-      #     context: *context
-      #     requires:
-      #       - deploy_to_live_dev
-      #       - deploy_to_live_production
+      - deploy_to_live_dev:
+          context: *context
+          requires:
+            - acceptance_tests
+          filters:
+            branches:
+              only:
+                - main
+      - deploy_to_live_production:
+          context: *context
+          requires:
+            - acceptance_tests
+          filters:
+            branches:
+              only:
+                - main
+      - smoke_tests:
+          context: *context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -88,8 +88,10 @@ module V2
             uploaded_files.each do |file|
               decrypted_submission['pages'].each do |page|
                 page['answers'].each do |answer|
+                  next unless answer['field_id'].match?(/upload/) || answer['field_id'].match?(/multiupload/)
+
                   # replace filename with link in answer, use gsub so it works on multiupload answers
-                  answer['answer'] = answer['answer'].gsub(file['filename'], file['ms_url']) if answer['answer'].include?(file['filename'])
+                  answer['answer'] = answer['answer'].gsub(file['filename'], file['ms_url'])
                 end
               end
             end

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -75,9 +75,22 @@ module V2
             )
 
             created_folder = create_folder_in_drive(submission.id)
+            uploaded_files = []
 
             attachments.each do |attachment|
-              send_attachment_to_drive(attachment, submission.id, created_folder)
+              response = send_attachment_to_drive(attachment, submission.id, created_folder)
+              uploaded_files << {
+                'filename' => attachment.filename,
+                'ms_url' => response['webUrl']
+              }
+            end
+
+            uploaded_files.each do |file|
+              decrypted_submission['pages'].each do |page|
+                page['answers'].each do |answer|
+                  answer['answer'] = "#{answer['answer']} #{file['ms_url']}" if answer['answer'].include?(file['filename'])
+                end
+              end
             end
           end
 

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -89,7 +89,7 @@ module V2
               decrypted_submission['pages'].each do |page|
                 page['answers'].each do |answer|
                   # replace filename with link in answer, use gsub so it works on multiupload answers
-                  answer['answer'] = answer['answer'].gsub(file['filename'], file['ms_url']) if answer['answer'] == file['filename']
+                  answer['answer'] = answer['answer'].gsub(file['filename'], file['ms_url']) if answer['answer'].include?(file['filename'])
                 end
               end
             end

--- a/app/jobs/v2/process_submission_job.rb
+++ b/app/jobs/v2/process_submission_job.rb
@@ -88,7 +88,8 @@ module V2
             uploaded_files.each do |file|
               decrypted_submission['pages'].each do |page|
                 page['answers'].each do |answer|
-                  answer['answer'] = "#{answer['answer']} #{file['ms_url']}" if answer['answer'].include?(file['filename'])
+                  # replace filename with link in answer, use gsub so it works on multiupload answers
+                  answer['answer'] = answer['answer'].gsub(file['filename'], file['ms_url']) if answer['answer'] == file['filename']
                 end
               end
             end

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -59,7 +59,7 @@ module V2
     end
 
     def send_attachment_to_drive(attachment, id, folder)
-      filename = CGI.escape("#{id}-#{attachment.filename}")
+      filename = CGI.escape(attachment.filename)
       uri = URI.parse("#{root_graph_url}sites/#{site_id}/drive/items/#{folder}:/#{filename}:/content")
 
       connection = Faraday.new(uri) do |conn|

--- a/app/services/v2/send_to_ms_graph_service.rb
+++ b/app/services/v2/send_to_ms_graph_service.rb
@@ -58,7 +58,7 @@ module V2
       end
     end
 
-    def send_attachment_to_drive(attachment, id, folder)
+    def send_attachment_to_drive(attachment, _id, folder)
       filename = CGI.escape(attachment.filename)
       uri = URI.parse("#{root_graph_url}sites/#{site_id}/drive/items/#{folder}:/#{filename}:/content")
 

--- a/spec/fixtures/payloads/valid_submission_with_file.json
+++ b/spec/fixtures/payloads/valid_submission_with_file.json
@@ -63,7 +63,7 @@
         {
           "field_id": "files_multiupload_1",
           "field_name": "Upload a picture of each dog",
-          "answer": "basset-hound-dog-picture.png"
+          "answer": "basset-hound-dog-picture.png; basset-hound-dog-picture (1).png"
         }
       ]
     },
@@ -120,6 +120,11 @@
       "filename": "basset-hound-dog-picture.png",
       "mimetype": "image/png",
       "url": "http://fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/dog-contest/user/1/123"
+    },
+    {
+      "filename": "basset-hound-dog-picture (1).png",
+      "mimetype": "image/png",
+      "url": "http://fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/dog-contest/user/1/456"
     }
   ]
 }

--- a/spec/fixtures/payloads/valid_submission_with_file.json
+++ b/spec/fixtures/payloads/valid_submission_with_file.json
@@ -1,0 +1,125 @@
+{
+  "service": {
+    "id": "fd5ef840-5f0f-4c1f-997e-5d6d89adf04f",
+    "slug": "mos-eisley",
+    "name": "Mos Eisley"
+  },
+  "meta": {
+    "pdf_heading":"Complain about working conditions on the star destroyer",
+    "pdf_subheading":"A copy of your complaint about working on a star destroyer"
+  },
+  "actions": [
+    {
+      "kind":"email",
+      "variant": "submission",
+      "to": "captain.needa@star-destroyer.com,admiral.piett@star-destroyer.com",
+      "from":"\"Email Output Acceptance Test Service\" <moj-online@digital.justice.gov.uk>",
+      "subject":"Email Output Acceptance Test submission: fc242acb-c03f-439e-b41d-bec76fa0f032",
+      "email_body":"Please find an application attached",
+      "include_pdf":true,
+      "include_attachments": true
+    },
+    {
+      "kind":"csv",
+      "variant": null,
+      "to": "captain.needa@star-destroyer.com,admiral.piett@star-destroyer.com",
+      "from":"\"Email Output Acceptance Test Service\" <moj-online@digital.justice.gov.uk>",
+      "subject":"CSV Output Acceptance Test submission: fc242acb-c03f-439e-b41d-bec76fa0f032",
+      "email_body":"",
+      "include_pdf": false,
+      "include_attachments": true
+    },
+    {
+      "kind": "json",
+      "variant": null,
+      "url": "http://api-endpoint.com",
+      "key": "fb730a667840d79c",
+      "include_attachments": false
+    },
+    {
+      "kind": "mslist",
+      "variant": null,
+      "graph_url": "graph-url.microsoft.com",
+      "site_id": "1234",
+      "list_id": "5678",
+      "drive_id": "root",
+      "include_attachments": true
+    }
+  ],
+  "pages": [
+    {
+      "heading": "",
+      "answers": [
+        {
+          "field_id": "name_text_1",
+          "field_name": "Full name",
+          "answer": "Captain Needa"
+        }
+      ]
+    },
+    {
+      "heading": "",
+      "answers": [
+        {
+          "field_id": "files_multiupload_1",
+          "field_name": "Upload a picture of each dog",
+          "answer": "basset-hound-dog-picture.png"
+        }
+      ]
+    },
+    {
+      "heading": "",
+      "answers": [
+        {
+          "field_id": "burgers_checkboxes_1",
+          "field_name": "What would you like on your burger?",
+          "answer": ["Beef, cheese, tomato", "Mozzarella, cheddar, feta"]
+        }
+      ]
+    },
+    {
+      "heading": "Your favourite droid",
+      "answers": [
+        {
+          "field_id": "multiple_question_1",
+          "field_name": "Multiple Question 1",
+          "answer": "C3P0"
+        },
+        {
+          "field_id": "multiple_question_2",
+          "field_name": "Multiple Question 2",
+          "answer": "R2D2"
+        },
+        {
+          "field_id": "multiple_question_3",
+          "field_name": "Multiple Question 3",
+          "answer": "BB8"
+        }
+      ]
+    },
+    {
+      "heading": "",
+      "answers": [
+        {
+          "field_id": "postal-address_address_1",
+          "field_name": "Your postal address",
+          "answer": {
+            "address_line_one": "1 road",
+            "address_line_two": "",
+            "city": "ruby town",
+            "county": "",
+            "postcode": "99 999",
+            "country": "ruby land"
+          }
+        }
+      ]
+    }
+  ],
+  "attachments": [
+    {
+      "filename": "basset-hound-dog-picture.png",
+      "mimetype": "image/png",
+      "url": "http://fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/dog-contest/user/1/123"
+    }
+  ]
+}

--- a/spec/jobs/v2/process_submission_job_spec.rb
+++ b/spec/jobs/v2/process_submission_job_spec.rb
@@ -215,6 +215,10 @@ RSpec.describe V2::ProcessSubmissionJob do
       end
 
       context 'when including attachments' do
+        let(:payload_fixture) do
+          JSON.parse(File.read(Rails.root.join('spec/fixtures/payloads/valid_submission_with_file.json')))
+        end
+
         before do
           # download attachment stub
           stub_request(:get, 'http://fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/dog-contest/user/1/123')
@@ -241,9 +245,10 @@ RSpec.describe V2::ProcessSubmissionJob do
           allow(ENV).to receive(:[]).with('SUBMISSION_DECRYPTION_KEY').and_return(key)
           allow(EmailOutputService).to receive(:new).and_return(email_output_service)
           allow(ms_graph_service).to receive(:create_folder_in_drive).and_return('a-folder')
+          allow(ms_graph_service).to receive(:send_attachment_to_drive).and_return({ 'webUrl' => 'https://drive/basset-hound-dog-picture.png' })
         end
 
-        it 'sends to graph api then attachments to drive api' do
+        it 'sends attachments to drive' do
           perform_job
 
           expect(ms_graph_service).to have_received(:send_attachment_to_drive) do |arg1, arg2, arg3|
@@ -251,9 +256,15 @@ RSpec.describe V2::ProcessSubmissionJob do
             expect(arg2).to eq(submission.id)
             expect(arg3).to eq('a-folder')
           end
+        end
+
+        it 'sends to graph api with drive links' do
+          perform_job
 
           expect(ms_graph_service).to have_received(:post_to_ms_list) do |arg1, arg2|
-            expect(arg1['submission_id']).to eq(submission.id)
+            expect(arg1['actions'][0]['kind']).to eq('mslist')
+            expect(arg1['pages'][1]['answers'][0]['answer']).to match(/https:\/\/drive\/basset-hound-dog-picture.png/)
+            expect(arg1['pages'][1]['answers'][0]['answer']).to match(/basset-hound-dog-picture.png/)
             expect(arg2).to eq(submission.id)
           end
         end

--- a/spec/jobs/v2/process_submission_job_spec.rb
+++ b/spec/jobs/v2/process_submission_job_spec.rb
@@ -224,9 +224,17 @@ RSpec.describe V2::ProcessSubmissionJob do
           stub_request(:get, 'http://fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/dog-contest/user/1/123')
             .to_return(status: 200, body: 'image', headers: {})
 
+          # download attachment stub
+          stub_request(:get, 'http://fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/dog-contest/user/1/456')
+            .to_return(status: 200, body: 'image', headers: {})
+
           # post to graph api stub
           stub_request(:post, 'https://rooturl.graph.example.com/sites/site_id/drive/items/root:/basset-hound-dog-picture.png:/content')
             .to_return(status: 200, body: response.to_json, headers: {})
+
+          # post to graph api stub
+          stub_request(:post, 'https://rooturl.graph.example.com/sites/site_id/drive/items/root:/basset-hound-dog-picture+(1).png:/content')
+          .to_return(status: 200, body: response.to_json, headers: {})
 
           # post create folder stub
           stub_request(:post, 'https://rooturl.graph.example.com/sites/site_id/drive/items/root/children')
@@ -245,17 +253,13 @@ RSpec.describe V2::ProcessSubmissionJob do
           allow(ENV).to receive(:[]).with('SUBMISSION_DECRYPTION_KEY').and_return(key)
           allow(EmailOutputService).to receive(:new).and_return(email_output_service)
           allow(ms_graph_service).to receive(:create_folder_in_drive).and_return('a-folder')
-          allow(ms_graph_service).to receive(:send_attachment_to_drive).and_return({ 'webUrl' => 'https://drive/basset-hound-dog-picture.png' })
+          allow(ms_graph_service).to receive(:send_attachment_to_drive).and_return({ 'webUrl' => 'https://drive/basset-hound-dog-picture.png' }, { 'webUrl' => 'https://drive/basset-hound-dog-picture+(1).png' })
         end
 
         it 'sends attachments to drive' do
           perform_job
 
-          expect(ms_graph_service).to have_received(:send_attachment_to_drive) do |arg1, arg2, arg3|
-            expect(arg1.filename).to match(/basset-hound-dog-picture.png/)
-            expect(arg2).to eq(submission.id)
-            expect(arg3).to eq('a-folder')
-          end
+          expect(ms_graph_service).to have_received(:send_attachment_to_drive).exactly(2).times
         end
 
         it 'sends to graph api with drive links' do
@@ -263,7 +267,8 @@ RSpec.describe V2::ProcessSubmissionJob do
 
           expect(ms_graph_service).to have_received(:post_to_ms_list) do |arg1, arg2|
             expect(arg1['actions'][0]['kind']).to eq('mslist')
-            expect(arg1['pages'][1]['answers'][0]['answer']).to match(/https:\/\/drive\/basset-hound-dog-picture.png/)
+            expect(arg1['pages'][1]['answers'][0]['answer']).to include('https://drive/basset-hound-dog-picture.png')
+            expect(arg1['pages'][1]['answers'][0]['answer']).to include('https://drive/basset-hound-dog-picture+(1).png')
             expect(arg2).to eq(submission.id)
           end
         end

--- a/spec/jobs/v2/process_submission_job_spec.rb
+++ b/spec/jobs/v2/process_submission_job_spec.rb
@@ -264,7 +264,6 @@ RSpec.describe V2::ProcessSubmissionJob do
           expect(ms_graph_service).to have_received(:post_to_ms_list) do |arg1, arg2|
             expect(arg1['actions'][0]['kind']).to eq('mslist')
             expect(arg1['pages'][1]['answers'][0]['answer']).to match(/https:\/\/drive\/basset-hound-dog-picture.png/)
-            expect(arg1['pages'][1]['answers'][0]['answer']).to match(/basset-hound-dog-picture.png/)
             expect(arg2).to eq(submission.id)
           end
         end

--- a/spec/services/v2/send_to_ms_graph_service_spec.rb
+++ b/spec/services/v2/send_to_ms_graph_service_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe V2::SendToMsGraphService do
 
     context 'when successful' do
       before do
-        stub_request(:put, "https://graph-url.microsoft.comsites/1234/drive/items/folder_path:/file+name.png:/content")
+        stub_request(:put, 'https://graph-url.microsoft.comsites/1234/drive/items/folder_path:/file+name.png:/content')
           .with(
             body: "hello world\n",
             headers: {

--- a/spec/services/v2/send_to_ms_graph_service_spec.rb
+++ b/spec/services/v2/send_to_ms_graph_service_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe V2::SendToMsGraphService do
 
     context 'when successful' do
       before do
-        stub_request(:put, "https://graph-url.microsoft.comsites/1234/drive/items/folder_path:/#{submission_id}-filename.png:/content")
+        stub_request(:put, "https://graph-url.microsoft.comsites/1234/drive/items/folder_path:/file+name.png:/content")
           .with(
             body: "hello world\n",
             headers: {
@@ -243,7 +243,7 @@ RSpec.describe V2::SendToMsGraphService do
 
         allow(ENV).to receive(:[]).with('MS_OAUTH_URL').and_return('https://authurl.example.com')
 
-        allow(attachment).to receive(:filename).and_return('filename.png')
+        allow(attachment).to receive(:filename).and_return('file name.png')
         allow(attachment).to receive(:path).and_return(Rails.root.join('spec/fixtures/files/hello_world.txt'))
       end
 


### PR DESCRIPTION
For the ms list payload, replace filenames in upload answers with links to the file that was uploaded to the drive.

The upload action will return a response that includes a `webUrl` field, then we match attachment filenames to answers and gsub them out.

Using gsub allows us to replace the filenames in multiupload answers, as they will be in the format `file_1; file_2; file_3 ...`

![image (15)](https://github.com/user-attachments/assets/24dacfc2-5b13-40d9-bfa8-02f3fb99cca7)
